### PR TITLE
Problem: no asyncio marker for ci

### DIFF
--- a/.github/workflows/tests-e2e-nix.yml
+++ b/.github/workflows/tests-e2e-nix.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 240
     strategy:
       matrix:
-        tests: [unmarked, slow]
+        tests: [asyncio, unmarked, slow]
     env:
       TESTS_TO_RUN: ${{ matrix.tests }}
     steps:

--- a/.github/workflows/tests-e2e-nix.yml
+++ b/.github/workflows/tests-e2e-nix.yml
@@ -54,7 +54,7 @@ jobs:
         run: make test-e2e-nix
       - name: 'Tar debug files'
         if: failure()
-        run: tar cfz debug_files.tar.gz -C "${TMPDIR-/tmp}/pytest-of-runner" .
+        run: tar cfz debug_files.tar.gz -C "${TMPDIR-/run/user/1001}/pytest-of-runner" .
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/tests-e2e-nix.yml
+++ b/.github/workflows/tests-e2e-nix.yml
@@ -54,7 +54,7 @@ jobs:
         run: make test-e2e-nix
       - name: 'Tar debug files'
         if: failure()
-        run: tar cfz debug_files.tar.gz -C "${TMPDIR-/run/user/1001}/pytest-of-runner" .
+        run: tar cfz debug_files.tar.gz -C "${TMPDIR-/tmp}/pytest-of-runner" .
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -14,6 +14,7 @@ from .network import (
 def pytest_configure(config):
     config.addinivalue_line("markers", "unmarked: fallback mark for unmarked tests")
     config.addinivalue_line("markers", "slow: marks tests as slow")
+    config.addinivalue_line("markers", "asyncio: marks tests as asyncio")
     config.addinivalue_line("markers", "connect: marks connect related tests")
 
 

--- a/integration_tests/test_async.py
+++ b/integration_tests/test_async.py
@@ -1,0 +1,27 @@
+import pytest
+from web3 import AsyncWeb3
+from web3.types import Wei
+
+from .utils import ADDRS
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_gas_price(mantra):
+    w3: AsyncWeb3 = mantra.async_w3
+    gas_price = await w3.eth.gas_price
+    assert gas_price > 0
+    tx = {
+        "from": ADDRS["validator"],
+        "to": ADDRS["community"],
+        "value": Wei(1000000000000000000),
+    }
+    estimated_gas = await w3.eth.estimate_gas(tx)
+    assert estimated_gas > 0
+
+
+async def test_gas_limit(mantra):
+    w3: AsyncWeb3 = mantra.async_w3
+    latest_block = await w3.eth.get_block("latest")
+    gas_limit = latest_block["gasLimit"]
+    assert gas_limit > 0

--- a/integration_tests/test_contract.py
+++ b/integration_tests/test_contract.py
@@ -30,6 +30,7 @@ from web3.types import Wei
 from .network import setup_custom_mantra
 from .utils import ADDRS
 
+pytestmark = pytest.mark.asyncio
 pytest.skip("fixed in v5", allow_module_level=True)
 
 
@@ -67,7 +68,6 @@ async def deploy_weth(w3: AsyncWeb3) -> None:
     assert address == WETH_ADDRESS, f"Expected {WETH_ADDRESS}, got {address}"
 
 
-@pytest.mark.asyncio
 async def test_flow(mantra_replay):
     w3 = mantra_replay.async_w3
     await ensure_create2_deployed(w3)

--- a/integration_tests/test_contract.py
+++ b/integration_tests/test_contract.py
@@ -30,6 +30,8 @@ from web3.types import Wei
 from .network import setup_custom_mantra
 from .utils import ADDRS
 
+pytest.skip("fixed in v5", allow_module_level=True)
+
 
 @pytest.fixture(scope="module")
 def mantra_replay(tmp_path_factory):

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -14,8 +14,8 @@ cd ..
 TESTS_TO_RUN="${TESTS_TO_RUN:-all}"
 
 if [[ "$TESTS_TO_RUN" == "all" ]]; then
-  echo "run all tests"
-  pytest -v -s -m unmarked
+  echo "run all local tests"
+  pytest -s -vvv -m "not connect"
 elif [[ "$TESTS_TO_RUN" == "connect" ]]; then
   if [ -f ../scripts/network.env ]; then
     echo "Loading environment variables from network.env"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded test coverage in continuous integration to include a new "asyncio" test category.
* **Tests**
  * Added a new marker for identifying asyncio-related tests.
  * Introduced asynchronous integration tests for Ethereum blockchain interactions.
  * Temporarily disabled a specific test module pending future updates.
  * Updated integration test script to refine test selection and increase verbosity for local test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->