### PR TITLE
Problem: mempool is not ready before block 2

### DIFF
--- a/integration_tests/network.py
+++ b/integration_tests/network.py
@@ -162,7 +162,7 @@ def setup_custom_mantra(
         c = Mantra(
             path / "mantra-canary-net-1", chain_binary=chain_binary or "mantrachaind"
         )
-        wait_for_block(c.cosmos_cli(), 1)
+        wait_for_block(c.cosmos_cli(), 2)
         yield c
     finally:
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)


### PR DESCRIPTION
Solution:
- wait a little bit more

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Integration test setup now waits for two blocks before proceeding, increasing initial synchronization time.
  * Results in more predictable readiness and standardized startup timing across runs.
  * May slightly lengthen test bootstrapping duration.
  * No changes to application features or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->