### PR TITLE
Problem: eip-2935 and HexAddressFromBech32String change is not tested

### DIFF
--- a/integration_tests/configs/upgrade-test-package.nix
+++ b/integration_tests/configs/upgrade-test-package.nix
@@ -89,7 +89,17 @@ let
     "v5.0.0-rc4" = mkMantrachain { version = "v5.0.0-rc4"; };
     "v5.0.0-rc5" = mkMantrachain { version = "v5.0.0-rc5"; };
     "v5.0" = pkgs.callPackage ../../nix/unify { };
-  };
+  } // (
+    pkgs.lib.optionalAttrs includeMantrachaind {
+      "v5.0.0-rc6" = pkgs.callPackage ../../nix/mantrachain { };
+    }
+  ) // (
+    pkgs.lib.optionalAttrs (!includeMantrachaind) {
+      "v5.0.0-rc6" = pkgs.writeShellScriptBin "mantrachaind" ''
+      exec mantrachaind "$@"
+    '';
+    }
+  );
 
 in
 pkgs.linkFarm "upgrade-test-package" (

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -523,8 +523,6 @@ def test_textual(mantra):
     assert rsp["code"] == 0, rsp["raw_log"]
 
 
-# TODO: add after next release
-@pytest.mark.skip(reason="skipping opBlockhash test")
 def test_op_blk_hash(mantra):
     w3 = mantra.w3
     contract = deploy_contract(w3, CONTRACTS["TestBlockTxProperties"])

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -523,7 +523,6 @@ def test_textual(mantra):
     assert rsp["code"] == 0, rsp["raw_log"]
 
 
-@pytest.mark.skip(reason="skipping opBlockhash test")
 def test_op_blk_hash(mantra):
     w3 = mantra.w3
     contract = deploy_contract(w3, CONTRACTS["TestBlockTxProperties"])

--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -188,6 +188,12 @@ def exec(c, tmp_path):
     gov_tx_af = get_tx(base_port, gov_txhash)
     assert is_subset(gov_tx_bf, gov_tx_af)
 
+    height = cli.block_height()
+    target_height = height + 15
+
+    cli = do_upgrade(c, "v5.0.0-rc6", target_height)
+    check_basic_eth_tx(c.w3, contract, acc_b, addr_a, "world rc6")
+
 
 def test_cosmovisor_upgrade(custom_mantra: Mantra, tmp_path):
     exec(custom_mantra, tmp_path)

--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -191,7 +191,7 @@ def exec(c, tmp_path):
     height = cli.block_height()
     target_height = height + 15
 
-    cli = do_upgrade(c, "v5.0.0-rc6", target_height)
+    cli = do_upgrade(c, "v5.0.0-rc6", target_height, gas_prices=DEFAULT_GAS_PRICE)
     check_basic_eth_tx(c.w3, contract, acc_b, addr_a, "world rc6")
 
 

--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -194,6 +194,9 @@ def exec(c, tmp_path):
     cli = do_upgrade(c, "v5.0.0-rc6", target_height, gas_prices=DEFAULT_GAS_PRICE)
     check_basic_eth_tx(c.w3, contract, acc_b, addr_a, "world rc6")
 
+    for limit in [1, 2]:
+        assert len(cli.query_erc20_token_pairs(limit=limit)) == limit
+
 
 def test_cosmovisor_upgrade(custom_mantra: Mantra, tmp_path):
     exec(custom_mantra, tmp_path)

--- a/integration_tests/test_upgrade_recent.py
+++ b/integration_tests/test_upgrade_recent.py
@@ -87,6 +87,19 @@ async def exec(c):
         "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
     ]
 
+    c.supervisorctl(
+        "start",
+        "mantra-canary-net-1-node0",
+        "mantra-canary-net-1-node1",
+        "mantra-canary-net-1-node2",
+    )
+    wait_for_new_blocks(cli, 1)
+
+    height = cli.block_height()
+    target_height = height + 15
+
+    cli = do_upgrade(c, "v5.0.0-rc6", target_height)
+
 
 async def test_cosmovisor_upgrade(custom_mantra: Mantra):
     await exec(custom_mantra)

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,10 +84,10 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "5f4f360f25a1c15d7864e845bbb2eed77ac1e84c";
-    hash = "sha256-1HlA8LGloNAMvMqqZx3Vd7bKklcq7UHT32Ca9E2iLk0=";
+    rev = "c4b7518f35201ecddb96099668706dfbd03f85dd";
+    hash = "sha256-TWP7qbY1gwGrcu5rwB6SaJtfTfxG+O1EMM/OJUBc6KY=";
   };
-  vendorHash = "sha256-rEEcmq5lCQl87axRFIN0qMrE+J02kfMhxhstFfpKGMc=";
+  vendorHash = "sha256-W/3MPbTWgGO6DjBlYJ1nWVpw0pgSRrIceJhHNJI1IYk=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,10 +84,10 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "c4b7518f35201ecddb96099668706dfbd03f85dd";
-    hash = "sha256-TWP7qbY1gwGrcu5rwB6SaJtfTfxG+O1EMM/OJUBc6KY=";
+    rev = "230a8d8f69444fd684cd9505751f96f2595b1a03";
+    hash = "sha256-qBRLtx3KMJ49mQfr1441meEmxRr91FB5LMAzQq/NB/E=";
   };
-  vendorHash = "sha256-W/3MPbTWgGO6DjBlYJ1nWVpw0pgSRrIceJhHNJI1IYk=";
+  vendorHash = "sha256-ctsB1H5jIxa663rJneDr0C3B0UwPvfoTdNvv+qnP8NY=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -82,12 +82,12 @@ buildGo123Module' rec {
     ;
   stdenv = buildStdenv;
   src = fetchFromGitHub {
-    owner = "MANTRA-Chain";
+    owner = "mmsqe";
     repo = pname;
-    rev = "3f144706adf71b82a8f4b82f8edf7bcd333d5d9a";
-    hash = "sha256-AkiI+lNCEIjBV75WOL3kb5N6FKonfMmfM8G1U6e1rvg=";
+    rev = "f5cfb28a2ac678416243d735d17c6fc58f78a457";
+    hash = "sha256-lRiZKrntK7lusCh255VF0TuHFXMzC9/gMfIAbr6X07I=";
   };
-  vendorHash = "sha256-CKcDR4fUX3NJe5sHgY/fO+5im0EQIfXzk3vI9MrV/Q0=";
+  vendorHash = "sha256-rbVNj/Dj2R6xM3GksK2fZ/T4CUCzw3sxGES+UpAPGNs=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -82,12 +82,12 @@ buildGo123Module' rec {
     ;
   stdenv = buildStdenv;
   src = fetchFromGitHub {
-    owner = "mmsqe";
+    owner = "MANTRA-Chain";
     repo = pname;
-    rev = "f5cfb28a2ac678416243d735d17c6fc58f78a457";
-    hash = "sha256-lRiZKrntK7lusCh255VF0TuHFXMzC9/gMfIAbr6X07I=";
+    rev = "512c38ee52ce1ba20bc9eda3af2db37ef4e5de7e";
+    hash = "sha256-AP7eiRkxvMhUO5mBIUh92xbIPRg6nHVFuJdu3WTKcCs=";
   };
-  vendorHash = "sha256-rbVNj/Dj2R6xM3GksK2fZ/T4CUCzw3sxGES+UpAPGNs=";
+  vendorHash = "sha256-F1q4Cro5nSKC1QwBrQqudzE5I5RYDnvs5NlAwbAObEA=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,10 +84,10 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "512c38ee52ce1ba20bc9eda3af2db37ef4e5de7e";
-    hash = "sha256-AP7eiRkxvMhUO5mBIUh92xbIPRg6nHVFuJdu3WTKcCs=";
+    rev = "5f4f360f25a1c15d7864e845bbb2eed77ac1e84c";
+    hash = "sha256-1HlA8LGloNAMvMqqZx3Vd7bKklcq7UHT32Ca9E2iLk0=";
   };
-  vendorHash = "sha256-F1q4Cro5nSKC1QwBrQqudzE5I5RYDnvs5NlAwbAObEA=";
+  vendorHash = "sha256-rEEcmq5lCQl87axRFIN0qMrE+J02kfMhxhstFfpKGMc=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";


### PR DESCRIPTION
depends on https://github.com/MANTRA-Chain/mantrachain/pull/416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add support for a v5.0.0-rc6 release in the test release set, exposed conditionally as a packaged binary or lightweight wrapper.

- **Tests**
  - Extend integration upgrade tests with v5.0.0-rc6 upgrade paths (multiple sequences), verify post-upgrade ETH and ERC20 behaviors, and clean up upgrade artifacts.

- **Chores**
  - Update upstream source and vendored metadata for Mantrachain to track the new commit and reproducible tarball.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->