### PR TITLE
Problem: op blockhash fix not tested

### DIFF
--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -104,6 +104,11 @@
             evm_denom: 'uom',
             allow_unprotected_txs: true,
           },
+          preinstalls: [{
+            name: 'EIP-2935 - Serve historical block hashes from state',
+            address: '0x0000F90827F1C53a10cb7A02335B175320002935',
+            code: '0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500',
+          }],
         },
         feemarket: {
           params: {

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -523,11 +523,11 @@ def test_textual(mantra):
     assert rsp["code"] == 0, rsp["raw_log"]
 
 
-@pytest.mark.skip(reason="skipping opBlockhash test")
 def test_op_blk_hash(mantra):
     w3 = mantra.w3
     contract = deploy_contract(w3, CONTRACTS["TestBlockTxProperties"])
     height = w3.eth.get_block_number()
+    print("height", height)
     w3_wait_for_new_blocks(w3, 1)
     res = contract.caller.getBlockHash(height).hex()
     blk = w3.eth.get_block(height)

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -527,7 +527,6 @@ def test_op_blk_hash(mantra):
     w3 = mantra.w3
     contract = deploy_contract(w3, CONTRACTS["TestBlockTxProperties"])
     height = w3.eth.get_block_number()
-    print("height", height)
     w3_wait_for_new_blocks(w3, 1)
     res = contract.caller.getBlockHash(height).hex()
     blk = w3.eth.get_block(height)


### PR DESCRIPTION
Solution:
- deploy storage contract in e2e, it's neccerary for eip-2935 to function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds EVM capability to retrieve historical block hashes from state via a preinstalled contract (EIP‑2935 compliant), available at genesis for consistent results across blocks.

- Tests
  - Re-enabled the blockhash operation test, increasing coverage and validating historical block hash retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->