### PR TITLE
Problem: contract deploy account is not aligned

### DIFF
--- a/integration_tests/test_contract.py
+++ b/integration_tests/test_contract.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 import pytest
+from eth_account import Account
 from eth_contract.contract import Contract, ContractFunction
 from eth_contract.create2 import create2_address
 from eth_contract.deploy_utils import (
@@ -58,7 +59,7 @@ MULTICALL3ROUTER = create2_address(
 
 
 async def assert_contract_deployed(w3):
-    account = (await w3.eth.accounts)[0]
+    account = Account.from_key(KEYS["community"])
     await ensure_create2_deployed(w3, account)
     await ensure_multicall3_deployed(w3, account)
     await ensure_deployed_by_create2(
@@ -85,61 +86,68 @@ async def test_connect_flow(connect_mantra):
 async def test_flow(mantra, connect_mantra):
     w3 = connect_mantra.async_w3
     await assert_contract_deployed(w3)
-    owner = (await w3.eth.accounts)[0]
-    await ensure_createx_deployed(w3, owner)
-    await ensure_history_storage_deployed(w3, owner)
+    key = KEYS["community"]
+    account = Account.from_key(KEYS["community"])
+    await ensure_createx_deployed(w3, account)
+    await ensure_history_storage_deployed(w3, account)
     assert await w3.eth.get_code(HISTORY_STORAGE_ADDRESS)
-    contract = await deploy_contract_async(w3, CONTRACTS["TestBlockTxProperties"])
+    contract = await deploy_contract_async(
+        w3, CONTRACTS["TestBlockTxProperties"], key=key
+    )
     height = await w3.eth.block_number
     await w3_wait_for_new_blocks_async(w3, 1)
     res = (await contract.caller.getBlockHash(height)).hex()
     blk = await w3.eth.get_block(height)
     assert res == blk.hash.hex(), res
 
+    owner = account.address
     # test_create2_deploy
     initcode = get_initcode(MockERC20_ARTIFACT, "TEST", "TEST", 18)
     salt = 100
-    token = await ensure_deployed_by_create2(w3, owner, initcode, salt=salt)
+    token = await ensure_deployed_by_create2(w3, account, initcode, salt=salt)
     assert token == "0x854d811d90C6E81B84b29C1d7ed957843cF87bba"
     balance = await ERC20.fns.balanceOf(owner).call(w3, to=token)
     amt = 1000
-    await ERC20.fns.mint(owner, amt).transact(w3, owner, to=token)
+    await ERC20.fns.mint(owner, amt).transact(w3, account, to=token)
     assert await ERC20.fns.balanceOf(owner).call(w3, to=token) == balance + amt
 
     # test_create3_deploy
     salt = 200
-    token = await ensure_deployed_by_create3(w3, owner, initcode, salt=salt)
+    token = await ensure_deployed_by_create3(w3, account, initcode, salt=salt)
     assert token == "0x60f7B32B5799838a480572Aee2A8F0355f607b38"
     balance = await ERC20.fns.balanceOf(owner).call(w3, to=token)
-    await ERC20.fns.mint(owner, 1000).transact(w3, owner, to=token)
+    await ERC20.fns.mint(owner, 1000).transact(w3, account, to=token)
     assert await ERC20.fns.balanceOf(owner).call(w3, to=token) == balance + amt
 
     # test_weth
     weth = WETH(to=WETH_ADDRESS)
     before = await balance_of(w3, ZERO_ADDRESS, owner)
-    receipt = await weth.fns.deposit().transact(w3, owner, value=1000)
+    receipt = await weth.fns.deposit().transact(w3, account, value=1000)
     fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
     await balance_of(w3, WETH_ADDRESS, owner) == 1000
-    receipt = await weth.fns.withdraw(1000).transact(w3, owner)
+    receipt = await weth.fns.withdraw(1000).transact(w3, account)
     fee += receipt["effectiveGasPrice"] * receipt["gasUsed"]
     await balance_of(w3, WETH_ADDRESS, owner) == 0
     assert await balance_of(w3, ZERO_ADDRESS, owner) == before - fee
 
     # test_batch_call
-    users = [ADDRS[key] for key in ["community", "signer1", "signer2"]]
+    users = [Account.from_key(KEYS[key]) for key in ["community", "signer1", "signer2"]]
     amount = 1000
     amount_all = amount * len(users)
 
-    balances = [(WETH_ADDRESS, ERC20.fns.balanceOf(user)) for user in users]
-    assert all(x == 0 for x in await multicall(w3, balances))
+    balances = [(WETH_ADDRESS, ERC20.fns.balanceOf(user.address)) for user in users]
+    balances_bf = await multicall(w3, balances)
     await MULTICALL3.fns.aggregate3Value(
         [Call3Value(WETH_ADDRESS, False, amount_all, weth.fns.deposit().data)]
         + [
-            Call3Value(WETH_ADDRESS, False, 0, ERC20.fns.transfer(user, amount).data)
+            Call3Value(
+                WETH_ADDRESS, False, 0, ERC20.fns.transfer(user.address, amount).data
+            )
             for user in users
         ]
     ).transact(w3, users[0], value=amount_all)
-    assert all(x == amount for x in await multicall(w3, balances))
+    balances_af = await multicall(w3, balances)
+    assert all(af - bf == amount for af, bf in zip(balances_af, balances_bf))
 
     for user in users:
         await ERC20.fns.approve(MULTICALL3_ADDRESS, amount).transact(
@@ -150,7 +158,9 @@ async def test_flow(mantra, connect_mantra):
         [
             Call3Value(
                 WETH_ADDRESS,
-                data=ERC20.fns.transferFrom(user, MULTICALL3_ADDRESS, amount).data,
+                data=ERC20.fns.transferFrom(
+                    user.address, MULTICALL3_ADDRESS, amount
+                ).data,
             )
             for user in users
         ]
@@ -158,36 +168,40 @@ async def test_flow(mantra, connect_mantra):
             Call3Value(
                 WETH_ADDRESS,
                 data=weth.fns.transferFrom(
-                    MULTICALL3_ADDRESS, users[0], amount_all
+                    MULTICALL3_ADDRESS, users[0].address, amount_all
                 ).data,
             ),
         ]
     ).transact(w3, users[0])
     await weth.fns.withdraw(amount_all).transact(w3, users[0], to=WETH_ADDRESS)
-    assert all(x == 0 for x in await multicall(w3, balances))
-    assert await balance_of(w3, WETH_ADDRESS, MULTICALL3_ADDRESS) == 0
+    balances_bf = await multicall(w3, balances)
+    await balance_of(w3, WETH_ADDRESS, MULTICALL3_ADDRESS) == 0
 
     # test_multicall3_router
     amount_all = amount * len(users)
     router = Contract(MULTICALL3ROUTER_ARTIFACT["abi"])
     multicall3 = MULTICALL3ROUTER
 
-    balances = [(WETH_ADDRESS, ERC20.fns.balanceOf(user)) for user in users]
-    assert all(x == 0 for x in await multicall(w3, balances))
-
-    before = await balance_of(w3, ZERO_ADDRESS, users[0])
+    balances = [(WETH_ADDRESS, ERC20.fns.balanceOf(user.address)) for user in users]
+    balances_bf = await multicall(w3, balances)
+    assert (await multicall(w3, balances)) == balances_bf
+    before = await balance_of(w3, ZERO_ADDRESS, users[0].address)
 
     # convert amount_all into WETH and distribute to users
     receipt = await MULTICALL3.fns.aggregate3Value(
         [Call3Value(WETH_ADDRESS, False, amount_all, WETH.fns.deposit().data)]
         + [
-            Call3Value(WETH_ADDRESS, False, 0, ERC20.fns.transfer(user, amount).data)
+            Call3Value(
+                WETH_ADDRESS, False, 0, ERC20.fns.transfer(user.address, amount).data
+            )
             for user in users
         ]
     ).transact(w3, users[0], to=multicall3, value=amount_all)
     before -= receipt["effectiveGasPrice"] * receipt["gasUsed"]
     # check users's weth balances
-    assert all(x == amount for x in await multicall(w3, balances))
+    balances_af = await multicall(w3, balances)
+    assert all(af - bf == amount for af, bf in zip(balances_af, balances_bf))
+    balances_bf = balances_af
 
     # approve multicall3 to transfer WETH on behalf of users
     for i, user in enumerate(users):
@@ -202,7 +216,8 @@ async def test_flow(mantra, connect_mantra):
     receipt = await MULTICALL3.fns.aggregate3Value(
         [
             Call3Value(
-                WETH_ADDRESS, data=ERC20.fns.transferFrom(user, multicall3, amount).data
+                WETH_ADDRESS,
+                data=ERC20.fns.transferFrom(user.address, multicall3, amount).data,
             )
             for user in users
         ]
@@ -210,18 +225,20 @@ async def test_flow(mantra, connect_mantra):
             Call3Value(WETH_ADDRESS, data=WETH.fns.withdraw(amount_all).data),
             Call3Value(
                 multicall3,
-                data=router.fns.sellToPool(ZERO_ADDRESS, 10000, users[0], 0, b"").data,
+                data=router.fns.sellToPool(
+                    ZERO_ADDRESS, 10000, users[0].address, 0, b""
+                ).data,
             ),
         ]
     ).transact(w3, users[0], to=multicall3)
     before -= receipt["effectiveGasPrice"] * receipt["gasUsed"]
-
-    assert all(x == 0 for x in await multicall(w3, balances))
+    balances_af = await multicall(w3, balances)
+    assert all(af + amount == bf for af, bf in zip(balances_af, balances_bf))
     assert await balance_of(w3, WETH_ADDRESS, multicall3) == 0
     assert await balance_of(w3, ZERO_ADDRESS, multicall3) == 0
 
     # user get all funds back other than gas fees
-    assert await balance_of(w3, ZERO_ADDRESS, users[0]) == before
+    assert await balance_of(w3, ZERO_ADDRESS, users[0].address) == before
 
 
 async def test_7702(mantra):

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -434,7 +434,7 @@ async def deploy_contract_async(
     w3: AsyncWeb3, jsonfile, args=(), key=KEYS["validator"], exp_gas_used=None
 ):
     tx, abi = await build_deploy_contract_async(w3, jsonfile, args, key)
-    txreceipt = await send_transaction_async(w3, tx["from"], **tx)
+    txreceipt = await send_transaction_async(w3, Account.from_key(key), **tx)
     if exp_gas_used is not None:
         assert (
             exp_gas_used == txreceipt.gasUsed


### PR DESCRIPTION
compare balance diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Standardized a deterministic account for all signing across deployments, token actions, WETH operations, and multicall/router flows.
  - Reworked batch/multicall tests to operate on explicit account addresses; updated balance checks to compare pre/post states.
  - Deployment and mint/transfer operations now use explicit account-based signing.

- Refactor
  - Consolidated signer/address handling across the integration test suite for consistency and clearer assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->