### PR TITLE
Problem: static erc20 precompile is not tested

### DIFF
--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -111,7 +111,7 @@
           ],
           token_pairs: [{
             erc20_address: '0x4200000000000000000000000000000000000006',
-            denom: 'uom',
+            denom: 'aom',
             enabled: true,
             contract_owner: 1,
           }],

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -105,6 +105,18 @@
             allow_unprotected_txs: true,
           },
         },
+        erc20: {
+          native_precompiles: [
+            '0x4200000000000000000000000000000000000006',
+          ],
+          token_pairs: [{
+            erc20_address: '0x4200000000000000000000000000000000000006',
+            denom: 'uom',
+            enabled: true,
+            contract_owner: 1,
+          }],
+
+        },
         feemarket: {
           params: {
             base_fee: '0.010000000000000000',

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -111,7 +111,7 @@
           ],
           token_pairs: [{
             erc20_address: '0x4200000000000000000000000000000000000006',
-            denom: 'aom',
+            denom: 'uom',
             enabled: true,
             contract_owner: 1,
           }],

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -105,18 +105,6 @@
             allow_unprotected_txs: true,
           },
         },
-        erc20: {
-          native_precompiles: [
-            '0x4200000000000000000000000000000000000006',
-          ],
-          token_pairs: [{
-            erc20_address: '0x4200000000000000000000000000000000000006',
-            denom: 'uom',
-            enabled: true,
-            contract_owner: 1,
-          }],
-
-        },
         feemarket: {
           params: {
             base_fee: '0.010000000000000000',

--- a/integration_tests/test_contract.py
+++ b/integration_tests/test_contract.py
@@ -131,10 +131,10 @@ async def test_flow(mantra, connect_mantra):
     before = await balance_of(w3, ZERO_ADDRESS, owner)
     receipt = await weth.fns.deposit().transact(w3, account, value=1000)
     fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    await balance_of(w3, WETH_ADDRESS, owner) == 1000
+    assert await balance_of(w3, WETH_ADDRESS, owner) == 1000
     receipt = await weth.fns.withdraw(1000).transact(w3, account)
     fee += receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    await balance_of(w3, WETH_ADDRESS, owner) == 0
+    assert await balance_of(w3, WETH_ADDRESS, owner) == 0
     assert await balance_of(w3, ZERO_ADDRESS, owner) == before - fee
 
     # test_batch_call

--- a/integration_tests/test_erc20.py
+++ b/integration_tests/test_erc20.py
@@ -1,0 +1,37 @@
+import pytest
+from eth_contract.erc20 import ERC20
+from eth_contract.weth import WETH
+from eth_utils import to_checksum_address
+
+from .utils import ACCOUNTS
+
+WOM = to_checksum_address("0x4200000000000000000000000000000000000006")
+
+
+@pytest.mark.asyncio
+async def test_static_erc20(mantra):
+    w3 = mantra.async_w3
+    acct = ACCOUNTS["validator"]
+    addr = acct.address
+    balance = await ERC20.fns.balanceOf(addr).call(w3, to=WOM)
+    assert balance > 0
+
+    # deposit should be nop
+    before = await w3.eth.get_balance(addr)
+    print("intial balance", before)
+    receipt = await WETH.fns.deposit().transact(w3, acct, value=10, to=WOM)
+    fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
+    after = await w3.eth.get_balance(addr)
+    assert after == before - fee
+
+    # withdraw should be nop
+    before = await w3.eth.get_balance(addr)
+    receipt = await WETH.fns.withdraw(100).transact(w3, acct, to=WOM)
+    fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
+    after = await w3.eth.get_balance(addr)
+    assert after == before - fee
+
+    # fail
+    assert await ERC20.fns.decimals().call(w3, to=WOM) == 9
+    assert await ERC20.fns.symbol().call(w3, to=WOM) == "uom"
+    assert await ERC20.fns.name().call(w3, to=WOM) == "uom"

--- a/integration_tests/test_erc20.py
+++ b/integration_tests/test_erc20.py
@@ -22,13 +22,13 @@ async def test_static_erc20(mantra, tmp_path):
     w3 = mantra.async_w3
     account = ACCOUNTS["community"]
     await ensure_create2_deployed(w3, account)
-    await ensure_deployed_by_create2(
+    weth_addr = await ensure_deployed_by_create2(
         w3,
         account,
         get_initcode(WETH9_ARTIFACT),
-        salt=WETH_SALT,
+        salt=WETH_SALT - 100,
     )
-
+    assert weth_addr != WETH_ADDRESS, "should be different weth address"
     owner = account.address
     submit_gov_proposal(
         mantra,
@@ -37,36 +37,38 @@ async def test_static_erc20(mantra, tmp_path):
             {
                 "@type": "/cosmos.evm.erc20.v1.MsgRegisterERC20",
                 "signer": module_address("gov"),
-                "erc20addresses": [WETH_ADDRESS],
+                "erc20addresses": [weth_addr],
             },
         ],
         gas=300000,
     )
     cli = mantra.cosmos_cli()
-    cli.query_erc20_token_pairs()
+    erc20_denom = f"erc20:{weth_addr}"
+    res = cli.query_erc20_token_pair(erc20_denom)
+    assert res["erc20_address"] == weth_addr, res
     # deposit should be nop
     before = await w3.eth.get_balance(owner)
-    weth = WETH(to=WETH_ADDRESS)
+    weth = WETH(to=weth_addr)
     before = await balance_of(w3, ZERO_ADDRESS, owner)
     receipt = await weth.fns.deposit().transact(w3, account, value=1000)
     fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    await balance_of(w3, WETH_ADDRESS, owner) == 1000
+    await balance_of(w3, weth_addr, owner) == 1000
     receipt = await weth.fns.withdraw(1000).transact(w3, account)
     fee += receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    await balance_of(w3, WETH_ADDRESS, owner) == 0
+    await balance_of(w3, weth_addr, owner) == 0
 
     # withdraw should be nop
-    weth = WETH(to=WETH_ADDRESS)
+    weth = WETH(to=weth_addr)
     before = await balance_of(w3, ZERO_ADDRESS, owner)
     receipt = await weth.fns.deposit().transact(w3, account, value=1000)
     fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    await balance_of(w3, WETH_ADDRESS, owner) == 1000
+    await balance_of(w3, weth_addr, owner) == 1000
     receipt = await weth.fns.withdraw(1000).transact(w3, account)
     fee += receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    await balance_of(w3, WETH_ADDRESS, owner) == 0
+    await balance_of(w3, weth_addr, owner) == 0
     assert await balance_of(w3, ZERO_ADDRESS, owner) == before - fee
 
     # fail
-    assert await ERC20.fns.decimals().call(w3, to=WETH_ADDRESS) == 18
-    assert await ERC20.fns.symbol().call(w3, to=WETH_ADDRESS) == "WETH"
-    assert await ERC20.fns.name().call(w3, to=WETH_ADDRESS) == "Wrapped Ether"
+    assert await ERC20.fns.decimals().call(w3, to=weth_addr) == 18
+    assert await ERC20.fns.symbol().call(w3, to=weth_addr) == "WETH"
+    assert await ERC20.fns.name().call(w3, to=weth_addr) == "Wrapped Ether"

--- a/integration_tests/test_erc20.py
+++ b/integration_tests/test_erc20.py
@@ -12,8 +12,7 @@ from .utils import (
     WETH9_ARTIFACT,
     WETH_ADDRESS,
     WETH_SALT,
-    module_address,
-    submit_gov_proposal,
+    assert_register_erc20_denom,
 )
 
 
@@ -29,23 +28,9 @@ async def test_static_erc20(mantra, tmp_path):
         salt=WETH_SALT - 100,
     )
     assert weth_addr != WETH_ADDRESS, "should be different weth address"
+    assert_register_erc20_denom(mantra, weth_addr, tmp_path)
     owner = account.address
-    submit_gov_proposal(
-        mantra,
-        tmp_path,
-        messages=[
-            {
-                "@type": "/cosmos.evm.erc20.v1.MsgRegisterERC20",
-                "signer": module_address("gov"),
-                "erc20addresses": [weth_addr],
-            },
-        ],
-        gas=300000,
-    )
-    cli = mantra.cosmos_cli()
-    erc20_denom = f"erc20:{weth_addr}"
-    res = cli.query_erc20_token_pair(erc20_denom)
-    assert res["erc20_address"] == weth_addr, res
+
     # deposit should be nop
     before = await w3.eth.get_balance(owner)
     weth = WETH(to=weth_addr)

--- a/integration_tests/test_erc20.py
+++ b/integration_tests/test_erc20.py
@@ -1,37 +1,72 @@
 import pytest
+from eth_contract.deploy_utils import (
+    ensure_create2_deployed,
+    ensure_deployed_by_create2,
+)
 from eth_contract.erc20 import ERC20
+from eth_contract.utils import ZERO_ADDRESS, balance_of, get_initcode
 from eth_contract.weth import WETH
-from eth_utils import to_checksum_address
 
-from .utils import ACCOUNTS
-
-WOM = to_checksum_address("0x4200000000000000000000000000000000000006")
+from .utils import (
+    ACCOUNTS,
+    WETH9_ARTIFACT,
+    WETH_ADDRESS,
+    WETH_SALT,
+    module_address,
+    submit_gov_proposal,
+)
 
 
 @pytest.mark.asyncio
-async def test_static_erc20(mantra):
+async def test_static_erc20(mantra, tmp_path):
     w3 = mantra.async_w3
-    acct = ACCOUNTS["validator"]
-    addr = acct.address
-    balance = await ERC20.fns.balanceOf(addr).call(w3, to=WOM)
-    assert balance > 0
+    account = ACCOUNTS["community"]
+    await ensure_create2_deployed(w3, account)
+    await ensure_deployed_by_create2(
+        w3,
+        account,
+        get_initcode(WETH9_ARTIFACT),
+        salt=WETH_SALT,
+    )
 
+    owner = account.address
+    submit_gov_proposal(
+        mantra,
+        tmp_path,
+        messages=[
+            {
+                "@type": "/cosmos.evm.erc20.v1.MsgRegisterERC20",
+                "signer": module_address("gov"),
+                "erc20addresses": [WETH_ADDRESS],
+            },
+        ],
+        gas=300000,
+    )
+    cli = mantra.cosmos_cli()
+    cli.query_erc20_token_pairs()
     # deposit should be nop
-    before = await w3.eth.get_balance(addr)
-    print("intial balance", before)
-    receipt = await WETH.fns.deposit().transact(w3, acct, value=10, to=WOM)
+    before = await w3.eth.get_balance(owner)
+    weth = WETH(to=WETH_ADDRESS)
+    before = await balance_of(w3, ZERO_ADDRESS, owner)
+    receipt = await weth.fns.deposit().transact(w3, account, value=1000)
     fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    after = await w3.eth.get_balance(addr)
-    assert after == before - fee
+    await balance_of(w3, WETH_ADDRESS, owner) == 1000
+    receipt = await weth.fns.withdraw(1000).transact(w3, account)
+    fee += receipt["effectiveGasPrice"] * receipt["gasUsed"]
+    await balance_of(w3, WETH_ADDRESS, owner) == 0
 
     # withdraw should be nop
-    before = await w3.eth.get_balance(addr)
-    receipt = await WETH.fns.withdraw(100).transact(w3, acct, to=WOM)
+    weth = WETH(to=WETH_ADDRESS)
+    before = await balance_of(w3, ZERO_ADDRESS, owner)
+    receipt = await weth.fns.deposit().transact(w3, account, value=1000)
     fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    after = await w3.eth.get_balance(addr)
-    assert after == before - fee
+    await balance_of(w3, WETH_ADDRESS, owner) == 1000
+    receipt = await weth.fns.withdraw(1000).transact(w3, account)
+    fee += receipt["effectiveGasPrice"] * receipt["gasUsed"]
+    await balance_of(w3, WETH_ADDRESS, owner) == 0
+    assert await balance_of(w3, ZERO_ADDRESS, owner) == before - fee
 
     # fail
-    assert await ERC20.fns.decimals().call(w3, to=WOM) == 9
-    assert await ERC20.fns.symbol().call(w3, to=WOM) == "uom"
-    assert await ERC20.fns.name().call(w3, to=WOM) == "uom"
+    assert await ERC20.fns.decimals().call(w3, to=WETH_ADDRESS) == 18
+    assert await ERC20.fns.symbol().call(w3, to=WETH_ADDRESS) == "WETH"
+    assert await ERC20.fns.name().call(w3, to=WETH_ADDRESS) == "Wrapped Ether"

--- a/integration_tests/test_ibc.py
+++ b/integration_tests/test_ibc.py
@@ -17,6 +17,7 @@ from .utils import (
     assert_create_erc20_denom,
     assert_create_tokenfactory_denom,
     assert_mint_tokenfactory_denom,
+    assert_register_erc20_denom,
     assert_tf_flow,
     assert_transfer_tokenfactory_denom,
     denom_to_erc20_address,
@@ -26,9 +27,7 @@ from .utils import (
     find_duplicate,
     generate_isolated_address,
     ibc_denom_address,
-    module_address,
     parse_events_rpc,
-    submit_gov_proposal,
     wait_for_fn,
     wait_for_fn_async,
 )
@@ -184,17 +183,7 @@ async def test_ibc_cb(ibc, tmp_path):
     erc20_denom, total = await assert_create_erc20_denom(w3, signer1)
 
     # check native erc20 transfer
-    submit_gov_proposal(
-        ibc.ibc1,
-        tmp_path,
-        messages=[
-            {
-                "@type": "/cosmos.evm.erc20.v1.MsgRegisterERC20",
-                "signer": module_address("gov"),
-                "erc20addresses": [WETH_ADDRESS],
-            }
-        ],
-    )
+    assert_register_erc20_denom(ibc.ibc1, WETH_ADDRESS, tmp_path)
 
     # mantra-canary-net-1 signer1 -> mantra-canary-net-2 signer2 50erc20_denom
     transfer_amt = total // 2

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -951,6 +951,24 @@ async def assert_create_erc20_denom(w3, signer):
     return erc20_denom, total
 
 
+def assert_register_erc20_denom(c, weth_addr, tmp_path):
+    submit_gov_proposal(
+        c,
+        tmp_path,
+        messages=[
+            {
+                "@type": "/cosmos.evm.erc20.v1.MsgRegisterERC20",
+                "signer": module_address("gov"),
+                "erc20addresses": [weth_addr],
+            },
+        ],
+        gas=300000,
+    )
+    erc20_denom = f"erc20:{weth_addr}"
+    res = c.cosmos_cli().query_erc20_token_pair(erc20_denom)
+    assert res["erc20_address"] == weth_addr, res
+
+
 def address_to_bytes32(addr) -> HexBytes:
     return HexBytes(addr).rjust(32, b"\x00")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added an async integration test covering wrapped-ETH (WETH) end-to-end: deployment via deterministic address, ERC20 registration, metadata checks (name, symbol, decimals), deposit/withdraw flows, balance assertions and fee accounting across repeated operations.
  - Introduced helper utilities to register ERC20 denoms and exercise transfer/approve/transferFrom flows, and tightened an existing test to assert WETH balance changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->