### PR TITLE
Problem: native_precompiles fix is not tested

### DIFF
--- a/integration_tests/configs/cosmovisor.jsonnet
+++ b/integration_tests/configs/cosmovisor.jsonnet
@@ -22,6 +22,7 @@ config {
       },
       app_state+: {
         evm:: super.evm,
+        erc20:: super.erc20,
         feemarket: {
           params: {
             alpha: '0.000000000000000000',

--- a/integration_tests/configs/cosmovisor_recent.jsonnet
+++ b/integration_tests/configs/cosmovisor_recent.jsonnet
@@ -16,6 +16,7 @@ config {
           params+: {
             native_precompiles: ['0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'],
           },
+          native_precompiles:: super.native_precompiles,
         },
       },
     },

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -105,6 +105,17 @@
             allow_unprotected_txs: true,
           },
         },
+        erc20: {
+          native_precompiles: [
+            '0x4200000000000000000000000000000000000006',
+          ],
+          token_pairs: [{
+            erc20_address: '0x4200000000000000000000000000000000000006',
+            denom: 'uom',
+            enabled: true,
+            contract_owner: 1,
+          }],
+        },
         feemarket: {
           params: {
             base_fee: '0.010000000000000000',

--- a/integration_tests/configs/upgrade-test-package.nix
+++ b/integration_tests/configs/upgrade-test-package.nix
@@ -11,13 +11,14 @@ let
     "v5.0.0-rc4" = common.mkMantrachain { version = "v5.0.0-rc4"; };
     "v5.0.0-rc5" = common.mkMantrachain { version = "v5.0.0-rc5"; };
     "v5.0.0-rc6" = common.mkMantrachain { version = "v5.0.0-rc6"; };
+    "v5.0" = pkgs.callPackage ../../nix/unify { };
   } // (
     pkgs.lib.optionalAttrs includeMantrachaind {
-      "v5.0" = pkgs.callPackage ../../nix/mantrachain { };
+      "v5.0.0-rc7" = pkgs.callPackage ../../nix/mantrachain { };
     }
   ) // (
     pkgs.lib.optionalAttrs (!includeMantrachaind) {
-      "v5.0" = pkgs.writeShellScriptBin "mantrachaind" ''
+      "v5.0.0-rc7" = pkgs.writeShellScriptBin "mantrachaind" ''
       exec mantrachaind "$@"
     '';
     }

--- a/integration_tests/configs/upgrade-test-package.nix
+++ b/integration_tests/configs/upgrade-test-package.nix
@@ -11,14 +11,14 @@ let
     "v5.0.0-rc4" = common.mkMantrachain { version = "v5.0.0-rc4"; };
     "v5.0.0-rc5" = common.mkMantrachain { version = "v5.0.0-rc5"; };
     "v5.0.0-rc6" = common.mkMantrachain { version = "v5.0.0-rc6"; };
-    "v5.0" = pkgs.callPackage ../../nix/unify { };
+    "v5.0.0-rc7" = pkgs.callPackage ../../nix/rc7 { };
   } // (
     pkgs.lib.optionalAttrs includeMantrachaind {
-      "v5.0.0-rc7" = pkgs.callPackage ../../nix/mantrachain { };
+      "v5.0" = pkgs.callPackage ../../nix/mantrachain { };
     }
   ) // (
     pkgs.lib.optionalAttrs (!includeMantrachaind) {
-      "v5.0.0-rc7" = pkgs.writeShellScriptBin "mantrachaind" ''
+      "v5.0" = pkgs.writeShellScriptBin "mantrachaind" ''
       exec mantrachaind "$@"
     '';
     }

--- a/integration_tests/test_erc20.py
+++ b/integration_tests/test_erc20.py
@@ -1,4 +1,5 @@
 import pytest
+import web3
 from eth_contract.erc20 import ERC20
 from eth_contract.weth import WETH
 from eth_utils import to_checksum_address
@@ -19,7 +20,7 @@ async def test_static_erc20(mantra):
     # deposit should be nop
     before = await w3.eth.get_balance(addr)
     print("intial balance", before)
-    receipt = await WETH.fns.deposit().transact(w3, acct, value=10, to=WOM)
+    receipt = await WETH.fns.deposit().transact(w3, acct, value=10**18, to=WOM)
     fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
     after = await w3.eth.get_balance(addr)
     assert after == before - fee
@@ -32,6 +33,10 @@ async def test_static_erc20(mantra):
     assert after == before - fee
 
     # fail
-    assert await ERC20.fns.decimals().call(w3, to=WOM) == 9
-    assert await ERC20.fns.symbol().call(w3, to=WOM) == "uom"
-    assert await ERC20.fns.name().call(w3, to=WOM) == "uom"
+    msg = "execution reverted"
+    with pytest.raises(web3.exceptions.ContractLogicError, match=msg):
+        assert await ERC20.fns.decimals().call(w3, to=WOM) == 9
+    with pytest.raises(web3.exceptions.ContractLogicError, match=msg):
+        assert await ERC20.fns.symbol().call(w3, to=WOM) == "uom"
+    with pytest.raises(web3.exceptions.ContractLogicError, match=msg):
+        assert await ERC20.fns.name().call(w3, to=WOM) == "uom"

--- a/integration_tests/test_erc20.py
+++ b/integration_tests/test_erc20.py
@@ -1,31 +1,37 @@
 import pytest
-from eth_contract.deploy_utils import (
-    ensure_create2_deployed,
-    ensure_deployed_by_create2,
-)
-from eth_contract.utils import get_initcode
+from eth_contract.erc20 import ERC20
+from eth_contract.weth import WETH
+from eth_utils import to_checksum_address
 
-from .utils import (
-    ACCOUNTS,
-    WETH9_ARTIFACT,
-    WETH_ADDRESS,
-    WETH_SALT,
-    assert_register_erc20_denom,
-    assert_weth_flow,
-)
+from .utils import ACCOUNTS
+
+WOM = to_checksum_address("0x4200000000000000000000000000000000000006")
 
 
 @pytest.mark.asyncio
-async def test_static_erc20(mantra, tmp_path):
+async def test_static_erc20(mantra):
     w3 = mantra.async_w3
-    account = ACCOUNTS["community"]
-    await ensure_create2_deployed(w3, account)
-    weth_addr = await ensure_deployed_by_create2(
-        w3,
-        account,
-        get_initcode(WETH9_ARTIFACT),
-        salt=WETH_SALT - 100,
-    )
-    assert weth_addr != WETH_ADDRESS, "should be different weth address"
-    assert_register_erc20_denom(mantra, weth_addr, tmp_path)
-    await assert_weth_flow(w3, weth_addr, account.address, account)
+    acct = ACCOUNTS["community"]
+    addr = acct.address
+    balance = await ERC20.fns.balanceOf(addr).call(w3, to=WOM)
+    assert balance > 0
+
+    # deposit should be nop
+    before = await w3.eth.get_balance(addr)
+    print("intial balance", before)
+    receipt = await WETH.fns.deposit().transact(w3, acct, value=10, to=WOM)
+    fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
+    after = await w3.eth.get_balance(addr)
+    assert after == before - fee
+
+    # withdraw should be nop
+    before = await w3.eth.get_balance(addr)
+    receipt = await WETH.fns.withdraw(100).transact(w3, acct, to=WOM)
+    fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
+    after = await w3.eth.get_balance(addr)
+    assert after == before - fee
+
+    # fail
+    assert await ERC20.fns.decimals().call(w3, to=WOM) == 9
+    assert await ERC20.fns.symbol().call(w3, to=WOM) == "uom"
+    assert await ERC20.fns.name().call(w3, to=WOM) == "uom"

--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -197,6 +197,12 @@ def exec(c, tmp_path):
     for limit in [1, 2]:
         assert len(cli.query_erc20_token_pairs(limit=limit)) == limit
 
+    height = cli.block_height()
+    target_height = height + 15
+
+    cli = do_upgrade(c, "v5.0.0-rc7", target_height, gas_prices=DEFAULT_GAS_PRICE)
+    check_basic_eth_tx(c.w3, contract, acc_b, addr_a, "world rc7")
+
 
 def test_cosmovisor_upgrade(custom_mantra: Mantra, tmp_path):
     exec(custom_mantra, tmp_path)

--- a/integration_tests/test_upgrade_recent.py
+++ b/integration_tests/test_upgrade_recent.py
@@ -100,6 +100,11 @@ async def exec(c):
 
     cli = do_upgrade(c, "v5.0.0-rc6", target_height)
 
+    height = cli.block_height()
+    target_height = height + 15
+
+    cli = do_upgrade(c, "v5.0.0-rc7", target_height)
+
 
 async def test_cosmovisor_upgrade(custom_mantra: Mantra):
     await exec(custom_mantra)

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -970,18 +970,7 @@ def assert_register_erc20_denom(c, addr, tmp_path):
 
 
 async def assert_weth_flow(w3, weth_addr, owner, account):
-    # deposit should be nop
     weth = WETH(to=weth_addr)
-    before = await balance_of(w3, ZERO_ADDRESS, owner)
-    receipt = await weth.fns.deposit().transact(w3, account, value=1000)
-    fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    assert await balance_of(w3, weth_addr, owner) == 1000
-    receipt = await weth.fns.withdraw(1000).transact(w3, account)
-    fee += receipt["effectiveGasPrice"] * receipt["gasUsed"]
-    assert await balance_of(w3, weth_addr, owner) == 0
-    assert await balance_of(w3, ZERO_ADDRESS, owner) == before - fee
-
-    # withdraw should be nop
     before = await balance_of(w3, ZERO_ADDRESS, owner)
     receipt = await weth.fns.deposit().transact(w3, account, value=1000)
     fee = receipt["effectiveGasPrice"] * receipt["gasUsed"]
@@ -990,11 +979,9 @@ async def assert_weth_flow(w3, weth_addr, owner, account):
     fee += receipt["effectiveGasPrice"] * receipt["gasUsed"]
     await balance_of(w3, weth_addr, owner) == 0
     assert await balance_of(w3, ZERO_ADDRESS, owner) == before - fee
-
-    # fail
-    assert await weth.fns.decimals().call(w3, to=weth_addr) == 18
-    assert await weth.fns.symbol().call(w3, to=weth_addr) == "WETH"
-    assert await weth.fns.name().call(w3, to=weth_addr) == "Wrapped Ether"
+    assert await weth.fns.decimals().call(w3) == 18
+    assert await weth.fns.symbol().call(w3) == "WETH"
+    assert await weth.fns.name().call(w3) == "Wrapped Ether"
 
 
 def address_to_bytes32(addr) -> HexBytes:

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,10 +84,10 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "948ac63b2058f717febaca446fcd9bba76f05282";
-    hash = "sha256-HtV7lwMJAOU+9/dQZ7bpEVj3fqig4tBfvIHcJRk9shM=";
+    rev = "e6ed705acdbeaaad7b9d667cbe2d0ecbe00f11f6";
+    hash = "sha256-RX+A1mlcz4BE6JPGYzBvNCCRuGha9c2MMo5lb8iKe1Y=";
   };
-  vendorHash = "sha256-P5HEXSgFmpyhvzHaDip1N5tyH9ZNk+S3OJ6jG8iTcac=";
+  vendorHash = "sha256-ORRo9PBeb4l559YpcmyJ8msfML/6TMOXmHX7+IbuxlQ=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,8 +84,8 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "8e1471d403b09a5cdcd76210ee57fab65665e471";
-    hash = "sha256-I5vy9lUNmRr+ODhHF4zbgRww2pbr0zPj+6qCo8Dt3ZA=";
+    rev = "bd389403f26ee41a0d1cf8f57fef79a78106db58";
+    hash = "sha256-3SgBnVk3A+Noq8HnXVsnHuRFDiI/YEZxv/XGkmgCIfA=";
   };
   vendorHash = "sha256-ORRo9PBeb4l559YpcmyJ8msfML/6TMOXmHX7+IbuxlQ=";
   proxyVendor = true;

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,10 +84,10 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "fb00e1c12f8da6ae6374dcb25a313606fd3ef29e";
-    hash = "sha256-fGZBy5Za1ouaBZGrMNWslvUZG6r1kKdFJdQnRfSYgg4=";
+    rev = "948ac63b2058f717febaca446fcd9bba76f05282";
+    hash = "sha256-HtV7lwMJAOU+9/dQZ7bpEVj3fqig4tBfvIHcJRk9shM=";
   };
-  vendorHash = "sha256-ORRo9PBeb4l559YpcmyJ8msfML/6TMOXmHX7+IbuxlQ=";
+  vendorHash = "sha256-P5HEXSgFmpyhvzHaDip1N5tyH9ZNk+S3OJ6jG8iTcac=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";

--- a/nix/rc7/default.nix
+++ b/nix/rc7/default.nix
@@ -84,8 +84,8 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "e6ed705acdbeaaad7b9d667cbe2d0ecbe00f11f6";
-    hash = "sha256-RX+A1mlcz4BE6JPGYzBvNCCRuGha9c2MMo5lb8iKe1Y=";
+    rev = "cdbf77c3924653b7261976e1a23f70f8442eac8b";
+    hash = "sha256-I5vy9lUNmRr+ODhHF4zbgRww2pbr0zPj+6qCo8Dt3ZA=";
   };
   vendorHash = "sha256-ORRo9PBeb4l559YpcmyJ8msfML/6TMOXmHX7+IbuxlQ=";
   proxyVendor = true;

--- a/nix/unify/default.nix
+++ b/nix/unify/default.nix
@@ -84,8 +84,8 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "8e1471d403b09a5cdcd76210ee57fab65665e471";
-    hash = "sha256-I5vy9lUNmRr+ODhHF4zbgRww2pbr0zPj+6qCo8Dt3ZA=";
+    rev = "e6ed705acdbeaaad7b9d667cbe2d0ecbe00f11f6";
+    hash = "sha256-RX+A1mlcz4BE6JPGYzBvNCCRuGha9c2MMo5lb8iKe1Y=";
   };
   vendorHash = "sha256-ORRo9PBeb4l559YpcmyJ8msfML/6TMOXmHX7+IbuxlQ=";
   proxyVendor = true;


### PR DESCRIPTION
depends on https://github.com/MANTRA-Chain/mantrachain/pull/424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enable ERC20 module in canary network configuration.
  - Add ERC20 integration to default config with native precompiles and a token pair for uom.
- Upgrades
  - Introduce upgrade path and package for version v5.0.0-rc7.
- Tests
  - Overhaul ERC20/WETH tests to perform direct on-chain interactions and validations.
  - Extend upgrade tests to cover v5.0.0-rc7.
- Chores
  - Update external source pin for the chain build.
  - Add new build configuration for the rc7 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->