### PR TITLE
Problem: can't run test against evmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This repository contains end-to-end integration tests for the MANTRA Chain proje
    ```
    or specific binary
    ```sh
-   export EVM_DENOM="atest" && pytest -vv -s test_basic.py::test_simple --chain-config evmd
+   pytest -vv -s test_basic.py::test_simple --chain-config evmd
    ```
 
 ### Nix Build Targets

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This repository contains end-to-end integration tests for the MANTRA Chain proje
    ```sh
    pytest -vv -s test_basic.py::test_multisig
    ```
+   or specific binary
+   ```sh
+   export EVM_DENOM="atest" && pytest -vv -s test_basic.py::test_simple --chain-config evmd
+   ```
 
 ### Nix Build Targets
 

--- a/integration_tests/configs/chains.jsonnet
+++ b/integration_tests/configs/chains.jsonnet
@@ -1,0 +1,10 @@
+{
+  evmd: {
+    evm_denom: 'atest',
+    cmd: 'evmd',
+  },
+  mantrachaind: {
+    evm_denom: 'uom',
+    cmd: 'mantrachaind',
+  },
+}

--- a/integration_tests/configs/chains.jsonnet
+++ b/integration_tests/configs/chains.jsonnet
@@ -2,9 +2,13 @@
   evmd: {
     evm_denom: 'atest',
     cmd: 'evmd',
+    chain_id: 9001,
+    evm_chain_id: 262144,
   },
   mantrachaind: {
     evm_denom: 'uom',
     cmd: 'mantrachaind',
+    chain_id: 'mantra-canary-net-1',
+    evm_chain_id: 5887,
   },
 }

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -1,7 +1,9 @@
+local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
+
 {
   dotenv: '../../scripts/.env',
   'mantra-canary-net-1': {
-    cmd: 'mantrachaind',
+    cmd: chain.cmd,
     'start-flags': '--trace',
     config: {
       mempool: {
@@ -16,7 +18,7 @@
       grpc: {
         'skip-check-header': true,
       },
-      'minimum-gas-prices': '0uom',
+      'minimum-gas-prices': '0' + chain.evm_denom,
       'index-events': ['ethereum_tx.ethereumTxHash'],
       'iavl-lazy-loading': true,
       'json-rpc': {
@@ -36,15 +38,15 @@
     },
     validators: [{
       'coin-type': 60,
-      coins: '100001000000uom',
-      staked: '1000000uom',
-      gas_prices: '0.01uom',
+      coins: '100000000000000000000' + chain.evm_denom,
+      staked: '10000000000000000000' + chain.evm_denom,
+      gas_prices: '0.01' + chain.evm_denom,
       mnemonic: '${VALIDATOR1_MNEMONIC}',
     }, {
       'coin-type': 60,
-      coins: '100001000000uom',
-      staked: '1000000uom',
-      gas_prices: '0.01uom',
+      coins: '100000000000000000000' + chain.evm_denom,
+      staked: '10000000000000000000' + chain.evm_denom,
+      gas_prices: '0.01' + chain.evm_denom,
       mnemonic: '${VALIDATOR2_MNEMONIC}',
       config: {
         db_backend: 'pebbledb',
@@ -54,9 +56,9 @@
       },
     }, {
       'coin-type': 60,
-      coins: '100001000000uom',
-      staked: '1000000uom',
-      gas_prices: '0.01uom',
+      coins: '100000000000000000000' + chain.evm_denom,
+      staked: '10000000000000000000' + chain.evm_denom,
+      gas_prices: '0.01' + chain.evm_denom,
       mnemonic: '${VALIDATOR3_MNEMONIC}',
       config: {
         db_backend: 'goleveldb',
@@ -68,22 +70,22 @@
     accounts: [{
       'coin-type': 60,
       name: 'community',
-      coins: '100000000000uom',
+      coins: '100000000000' + chain.evm_denom,
       mnemonic: '${COMMUNITY_MNEMONIC}',
     }, {
       'coin-type': 60,
       name: 'signer1',
-      coins: '200000000000uom',
+      coins: '200000000000' + chain.evm_denom,
       mnemonic: '${SIGNER1_MNEMONIC}',
     }, {
       'coin-type': 60,
       name: 'signer2',
-      coins: '300000000000uom',
+      coins: '300000000000' + chain.evm_denom,
       mnemonic: '${SIGNER2_MNEMONIC}',
     }, {
       'coin-type': 60,
       name: 'reserve',
-      coins: '100000000000uom',
+      coins: '100000000000' + chain.evm_denom,
       vesting: '60s',
     }],
     genesis: {
@@ -101,8 +103,7 @@
       app_state: {
         evm: {
           params: {
-            evm_denom: 'uom',
-            allow_unprotected_txs: true,
+            evm_denom: chain.evm_denom,
           },
         },
         erc20: {
@@ -111,7 +112,7 @@
           ],
           token_pairs: [{
             erc20_address: '0x4200000000000000000000000000000000000006',
-            denom: 'uom',
+            denom: chain.evm_denom,
             enabled: true,
             contract_owner: 1,
           }],
@@ -130,13 +131,13 @@
             max_deposit_period: '10s',
             min_deposit: [
               {
-                denom: 'uom',
+                denom: chain.evm_denom,
                 amount: '1',
               },
             ],
             expedited_min_deposit: [
               {
-                denom: 'uom',
+                denom: chain.evm_denom,
                 amount: '2',
               },
             ],
@@ -154,7 +155,7 @@
         },
         staking: {
           params: {
-            bond_denom: 'uom',
+            bond_denom: chain.evm_denom,
           },
         },
       },

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -70,22 +70,22 @@ local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
     accounts: [{
       'coin-type': 60,
       name: 'community',
-      coins: '100000000000' + chain.evm_denom,
+      coins: '100000000000000000000' + chain.evm_denom + ',1000000000000atoken',
       mnemonic: '${COMMUNITY_MNEMONIC}',
     }, {
       'coin-type': 60,
       name: 'signer1',
-      coins: '200000000000' + chain.evm_denom,
+      coins: '100000000000000000000' + chain.evm_denom,
       mnemonic: '${SIGNER1_MNEMONIC}',
     }, {
       'coin-type': 60,
       name: 'signer2',
-      coins: '300000000000' + chain.evm_denom,
+      coins: '100000000000000000000' + chain.evm_denom,
       mnemonic: '${SIGNER2_MNEMONIC}',
     }, {
       'coin-type': 60,
       name: 'reserve',
-      coins: '100000000000' + chain.evm_denom,
+      coins: '100000000000000000000' + chain.evm_denom,
       mnemonic: '${RESERVE_MNEMONIC}',
       vesting: '60s',
     }],
@@ -105,6 +105,9 @@ local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
         evm: {
           params: {
             evm_denom: chain.evm_denom,
+            active_static_precompiles: [
+              '0x0000000000000000000000000000000000000807',
+            ],
           },
         },
         erc20: {
@@ -158,6 +161,24 @@ local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
           params: {
             bond_denom: chain.evm_denom,
           },
+        },
+        bank: {
+          denom_metadata: [{
+            denom_units: [
+              {
+                denom: 'atoken',
+                exponent: 0,
+              },
+              {
+                denom: 'token',
+                exponent: 18,
+              },
+            ],
+            base: 'atoken',
+            display: 'token',
+            name: 'Test Coin',
+            symbol: 'ATOKEN',
+          }],
         },
       },
     },

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -13,7 +13,7 @@ local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
     'app-config': {
       chain_id: 'mantra-canary-net-1',
       evm: {
-        'evm-chain-id': 5887,
+        'evm-chain-id': chain.evm_chain_id,
       },
       grpc: {
         'skip-check-header': true,

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -105,6 +105,7 @@ local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
         evm: {
           params: {
             evm_denom: chain.evm_denom,
+            allow_unprotected_txs: true,
             active_static_precompiles: [
               '0x0000000000000000000000000000000000000807',
             ],

--- a/integration_tests/configs/mantrachaind.jsonnet
+++ b/integration_tests/configs/mantrachaind.jsonnet
@@ -1,4 +1,0 @@
-{
-  evm_denom: 'uom',
-  cmd: 'mantrachaind',
-}

--- a/integration_tests/configs/mantrachaind.jsonnet
+++ b/integration_tests/configs/mantrachaind.jsonnet
@@ -1,0 +1,4 @@
+{
+  evm_denom: 'uom',
+  cmd: 'mantrachaind',
+}

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -7,6 +7,17 @@ from .network import (
 )
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--chain-config",
+        default="mantrachaind",
+        action="store",
+        metavar="CHAIN_CONFIG",
+        required=False,
+        help="Specify chain config to test",
+    )
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "unmarked: fallback mark for unmarked tests")
     config.addinivalue_line("markers", "slow: marks tests as slow")
@@ -61,8 +72,9 @@ def suspend_capture(pytestconfig):
 
 @pytest.fixture(scope="session", params=[True])
 def mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("mantra")
-    yield from setup_mantra(path, 26650)
+    yield from setup_mantra(path, 26650, chain)
 
 
 @pytest.fixture(scope="session", params=[True])

--- a/integration_tests/ibc_utils.py
+++ b/integration_tests/ibc_utils.py
@@ -52,13 +52,14 @@ def call_hermes_cmd(hermes, incentivized, version):
     )
 
 
-def prepare_network(tmp_path, name):
+def prepare_network(tmp_path, name, chain):
     name = f"configs/{name}.jsonnet"
     with contextmanager(setup_custom_mantra)(
         tmp_path,
         27000,
         Path(__file__).parent / name,
         relayer=cluster.Relayer.HERMES.value,
+        chain=chain,
     ) as ibc1:
         cli = ibc1.cosmos_cli()
         ibc2 = Mantra(ibc1.base_dir.parent / "mantra-canary-net-2")

--- a/integration_tests/network.py
+++ b/integration_tests/network.py
@@ -2,7 +2,6 @@ import json
 import os
 import signal
 import subprocess
-import tempfile
 from pathlib import Path
 
 import _jsonnet

--- a/integration_tests/network.py
+++ b/integration_tests/network.py
@@ -220,7 +220,7 @@ def setup_custom_mantra(
     try:
         if wait_port:
             wait_for_port(ports.rpc_port(base_port))
-        c = Mantra(path / CHAIN_ID, chain_binary=chain_binary or "mantrachaind")
+        c = Mantra(path / CHAIN_ID, chain_binary=chain_binary or chain)
         wait_for_block(c.cosmos_cli(), 1)
         yield c
     finally:

--- a/integration_tests/network.py
+++ b/integration_tests/network.py
@@ -170,14 +170,7 @@ class ConnectMantra:
 
 def setup_mantra(path, base_port, chain):
     cfg = Path(__file__).parent / ("configs/default.jsonnet")
-    data = json.loads(
-        _jsonnet.evaluate_file(str(cfg), ext_vars={"CHAIN_CONFIG": chain})
-    )
-    data = expand(data, None, cfg)
-    with tempfile.NamedTemporaryFile("w", suffix=".json") as f:
-        f.write(json.dumps(data))
-        f.flush()
-        yield from setup_custom_mantra(path, base_port, f.name, chain_binary=chain)
+    yield from setup_custom_mantra(path, base_port, cfg, chain=chain)
 
 
 def setup_custom_mantra(
@@ -189,40 +182,50 @@ def setup_custom_mantra(
     wait_port=True,
     relayer=cluster.Relayer.HERMES.value,
     genesis=None,
+    chain=None,
 ):
-    cmd = [
-        "pystarport",
-        "init",
-        "--config",
-        config,
-        "--data",
-        path,
-        "--base_port",
-        str(base_port),
-        "--no_remove",
-    ]
-    if relayer == cluster.Relayer.RLY.value:
-        cmd = cmd + ["--relayer", str(relayer)]
-    if chain_binary is not None:
-        cmd = cmd[:1] + ["--cmd", chain_binary] + cmd[1:]
-    print(*cmd)
-    subprocess.run(cmd, check=True)
-    if post_init is not None:
-        post_init(path, base_port, config, genesis)
-    proc = subprocess.Popen(
-        ["pystarport", "start", "--data", path, "--quiet"],
-        preexec_fn=os.setsid,
-    )
-    try:
-        if wait_port:
-            wait_for_port(ports.rpc_port(base_port))
-        c = Mantra(path / CHAIN_ID, chain_binary=chain_binary or "mantrachaind")
-        wait_for_block(c.cosmos_cli(), 1)
-        yield c
-    finally:
-        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        # proc.terminate()
-        proc.wait()
+    if config.suffix == ".jsonnet":
+        data = json.loads(
+            _jsonnet.evaluate_file(str(config), ext_vars={"CHAIN_CONFIG": chain})
+        )
+        data = expand(data, None, config)
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as f:
+            f.write(json.dumps(data))
+            f.flush()
+            config = f.name
+            cmd = [
+                "pystarport",
+                "init",
+                "--config",
+                config,
+                "--data",
+                path,
+                "--base_port",
+                str(base_port),
+                "--no_remove",
+            ]
+            if relayer == cluster.Relayer.RLY.value:
+                cmd = cmd + ["--relayer", str(relayer)]
+            if chain_binary is not None:
+                cmd = cmd[:1] + ["--cmd", chain_binary] + cmd[1:]
+            print(*cmd)
+            subprocess.run(cmd, check=True)
+            if post_init is not None:
+                post_init(path, base_port, config, genesis)
+            proc = subprocess.Popen(
+                ["pystarport", "start", "--data", path, "--quiet"],
+                preexec_fn=os.setsid,
+            )
+            try:
+                if wait_port:
+                    wait_for_port(ports.rpc_port(base_port))
+                c = Mantra(path / CHAIN_ID, chain_binary=chain_binary or "mantrachaind")
+                wait_for_block(c.cosmos_cli(), 1)
+                yield c
+            finally:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                # proc.terminate()
+                proc.wait()
 
 
 def connect_custom_mantra():

--- a/integration_tests/network.py
+++ b/integration_tests/network.py
@@ -184,48 +184,49 @@ def setup_custom_mantra(
     genesis=None,
     chain=None,
 ):
-    if config.suffix == ".jsonnet":
-        data = json.loads(
-            _jsonnet.evaluate_file(str(config), ext_vars={"CHAIN_CONFIG": chain})
-        )
-        data = expand(data, None, config)
-        with tempfile.NamedTemporaryFile("w", suffix=".json") as f:
-            f.write(json.dumps(data))
-            f.flush()
-            config = f.name
-            cmd = [
-                "pystarport",
-                "init",
-                "--config",
-                config,
-                "--data",
-                path,
-                "--base_port",
-                str(base_port),
-                "--no_remove",
-            ]
-            if relayer == cluster.Relayer.RLY.value:
-                cmd = cmd + ["--relayer", str(relayer)]
-            if chain_binary is not None:
-                cmd = cmd[:1] + ["--cmd", chain_binary] + cmd[1:]
-            print(*cmd)
-            subprocess.run(cmd, check=True)
-            if post_init is not None:
-                post_init(path, base_port, config, genesis)
-            proc = subprocess.Popen(
-                ["pystarport", "start", "--data", path, "--quiet"],
-                preexec_fn=os.setsid,
-            )
-            try:
-                if wait_port:
-                    wait_for_port(ports.rpc_port(base_port))
-                c = Mantra(path / CHAIN_ID, chain_binary=chain_binary or "mantrachaind")
-                wait_for_block(c.cosmos_cli(), 1)
-                yield c
-            finally:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-                # proc.terminate()
-                proc.wait()
+    assert config.suffix == ".jsonnet"
+
+    # expand jsonnet with ext vars
+    data = json.loads(
+        _jsonnet.evaluate_file(str(config), ext_vars={"CHAIN_CONFIG": chain})
+    )
+    data = expand(data, None, config)
+    config = path / "expanded_config.json"
+    config.write_text(json.dumps(data, indent=2))
+
+    cmd = [
+        "pystarport",
+        "init",
+        "--config",
+        config,
+        "--data",
+        path,
+        "--base_port",
+        str(base_port),
+        "--no_remove",
+    ]
+    if relayer == cluster.Relayer.RLY.value:
+        cmd = cmd + ["--relayer", str(relayer)]
+    if chain_binary is not None:
+        cmd = cmd[:1] + ["--cmd", chain_binary] + cmd[1:]
+    print(*cmd)
+    subprocess.run(cmd, check=True)
+    if post_init is not None:
+        post_init(path, base_port, config, genesis)
+    proc = subprocess.Popen(
+        ["pystarport", "start", "--data", path, "--quiet"],
+        preexec_fn=os.setsid,
+    )
+    try:
+        if wait_port:
+            wait_for_port(ports.rpc_port(base_port))
+        c = Mantra(path / CHAIN_ID, chain_binary=chain_binary or "mantrachaind")
+        wait_for_block(c.cosmos_cli(), 1)
+        yield c
+    finally:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        # proc.terminate()
+        proc.wait()
 
 
 def connect_custom_mantra():

--- a/integration_tests/poetry.lock
+++ b/integration_tests/poetry.lock
@@ -1928,7 +1928,7 @@ tomlkit = "^0"
 type = "git"
 url = "https://github.com/MANTRA-Chain/pystarport.git"
 reference = "app_config"
-resolved_reference = "b143725e193e3b7fba4899653aa18d4b7a23ed27"
+resolved_reference = "060561102b285667ac41ceeb2e3738cc59133a54"
 
 [[package]]
 name = "pytest"

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -25,6 +25,7 @@ from .utils import (
     recover_community,
     send_transaction,
     transfer_via_cosmos,
+    w3_wait_for_new_blocks,
 )
 
 
@@ -252,6 +253,7 @@ def test_transaction(mantra):
         ),
     }
 
+    w3_wait_for_new_blocks(w3, 1)
     with ThreadPoolExecutor(4) as executor:
         future_to_contract = {
             executor.submit(contract.deploy, w3): name
@@ -261,6 +263,7 @@ def test_transaction(mantra):
         assert_receipt_transaction_and_block(w3, future_to_contract)
 
     # Do Multiple contract calls
+    w3_wait_for_new_blocks(w3, 1)
     with ThreadPoolExecutor(4) as executor:
         futures = []
         futures.append(
@@ -274,14 +277,10 @@ def test_transaction(mantra):
 
         assert_receipt_transaction_and_block(w3, futures)
 
-        # revert transaction
-        assert futures[0].result()["status"] == 0
-        # normal transaction
-        assert futures[1].result()["status"] == 1
-        # normal transaction
-        assert futures[2].result()["status"] == 1
-        # normal transaction
-        assert futures[3].result()["status"] == 1
+        # revert transaction for 1st, normal transaction for others
+        statuses = [0, 1, 1, 1]
+        for i, future in enumerate(futures):
+            assert future.result()["status"] == statuses[i]
 
 
 def assert_receipt_transaction_and_block(w3, futures):

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -43,11 +43,12 @@ def test_simple(mantra, connect_mantra, tmp_path, check_reserve=True):
     if check_reserve:
         # check vesting account
         cli = mantra.cosmos_cli()
+        denom = cli.get_params("evm")["params"]["evm_denom"]
         addr = cli.address("reserve")
         account = cli.account(addr)["account"]
         assert account["type"] == "/cosmos.vesting.v1beta1.DelayedVestingAccount"
         assert account["value"]["base_vesting_account"]["original_vesting"] == [
-            {"denom": DEFAULT_DENOM, "amount": "100000000000000000000"}
+            {"denom": denom, "amount": "100000000000000000000"}
         ]
 
 

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -46,7 +46,7 @@ def test_simple(mantra, connect_mantra, tmp_path, check_reserve=True):
         account = cli.account(addr)["account"]
         assert account["type"] == "/cosmos.vesting.v1beta1.DelayedVestingAccount"
         assert account["value"]["base_vesting_account"]["original_vesting"] == [
-            {"denom": DEFAULT_DENOM, "amount": "100000000000"}
+            {"denom": DEFAULT_DENOM, "amount": "100000000000000000000"}
         ]
 
 
@@ -158,6 +158,7 @@ async def test_minimal_gas_price(mantra, connect_mantra):
     assert receipt.status == 1
 
 
+@pytest.mark.flaky(max_runs=3)
 def test_transaction(mantra):
     w3 = mantra.w3
     gas_price = w3.eth.gas_price

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -159,7 +159,6 @@ async def test_minimal_gas_price(mantra, connect_mantra):
     assert receipt.status == 1
 
 
-@pytest.mark.flaky(max_runs=3)
 def test_transaction(mantra):
     w3 = mantra.w3
     gas_price = w3.eth.gas_price

--- a/integration_tests/test_exploit.py
+++ b/integration_tests/test_exploit.py
@@ -12,10 +12,14 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture(scope="module")
-def custom_mantra(tmp_path_factory):
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("exploit")
     yield from setup_custom_mantra(
-        path, 26910, Path(__file__).parent / "configs/exploit.jsonnet"
+        path,
+        26910,
+        Path(__file__).parent / "configs/exploit.jsonnet",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_fee_history.py
+++ b/integration_tests/test_fee_history.py
@@ -22,10 +22,14 @@ pytestmark = pytest.mark.slow
 
 
 @pytest.fixture(scope="module")
-def custom_mantra(tmp_path_factory):
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("fee-history")
     yield from setup_custom_mantra(
-        path, 26500, Path(__file__).parent / "configs/fee-history.jsonnet"
+        path,
+        26500,
+        Path(__file__).parent / "configs/fee-history.jsonnet",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_ibc.py
+++ b/integration_tests/test_ibc.py
@@ -35,11 +35,12 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture(scope="module")
-def ibc(tmp_path_factory):
+def ibc(request, tmp_path_factory):
     "prepare-network"
     name = "ibc"
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp(name)
-    yield from prepare_network(path, name)
+    yield from prepare_network(path, name, chain)
 
 
 def assert_dynamic_fee(cli):

--- a/integration_tests/test_mempool.py
+++ b/integration_tests/test_mempool.py
@@ -15,10 +15,14 @@ from .utils import (
 
 
 @pytest.fixture(scope="module")
-def mantra_mempool(tmp_path_factory):
+def mantra_mempool(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("mantra-mempool")
     yield from setup_custom_mantra(
-        path, 26300, Path(__file__).parent / "configs/long_timeout_commit.jsonnet"
+        path,
+        26300,
+        Path(__file__).parent / "configs/long_timeout_commit.jsonnet",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_min_gas_price.py
+++ b/integration_tests/test_min_gas_price.py
@@ -15,26 +15,38 @@ from .utils import (
 
 
 @pytest.fixture(scope="module")
-def custom_mantra_eq(tmp_path_factory):
+def custom_mantra_eq(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("min-gas-price-eq")
     yield from setup_custom_mantra(
-        path, 26500, Path(__file__).parent / "configs/min_gas_price_eq.jsonnet"
+        path,
+        26500,
+        Path(__file__).parent / "configs/min_gas_price_eq.jsonnet",
+        chain=chain,
     )
 
 
 @pytest.fixture(scope="module")
-def custom_mantra(tmp_path_factory):
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("min-gas-price")
     yield from setup_custom_mantra(
-        path, 26530, Path(__file__).parent / "configs/min_gas_price.jsonnet"
+        path,
+        26530,
+        Path(__file__).parent / "configs/min_gas_price.jsonnet",
+        chain=chain,
     )
 
 
 @pytest.fixture(scope="module")
-def custom_mantra_lte(tmp_path_factory):
+def custom_mantra_lte(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("min-gas-price-lte")
     yield from setup_custom_mantra(
-        path, 26560, Path(__file__).parent / "configs/min_gas_price_lte.jsonnet"
+        path,
+        26560,
+        Path(__file__).parent / "configs/min_gas_price_lte.jsonnet",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_permission.py
+++ b/integration_tests/test_permission.py
@@ -16,10 +16,14 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture(scope="module")
-def custom_mantra(tmp_path_factory):
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("permission")
     yield from setup_custom_mantra(
-        path, 26700, Path(__file__).parent / "configs/accounts.jsonnet"
+        path,
+        26700,
+        Path(__file__).parent / "configs/accounts.jsonnet",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_pruned_node.py
+++ b/integration_tests/test_pruned_node.py
@@ -22,10 +22,12 @@ def mantra(request, tmp_path_factory):
     """start-mantra
     params: enable_auto_deployment
     """
+    chain = request.config.getoption("chain_config")
     yield from setup_custom_mantra(
         tmp_path_factory.mktemp("pruned"),
         26900,
         Path(__file__).parent / "configs/pruned-node.jsonnet",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_replay.py
+++ b/integration_tests/test_replay.py
@@ -11,10 +11,14 @@ from .utils import send_transaction
 
 
 @pytest.fixture(scope="module")
-def mantra_replay(tmp_path_factory):
+def mantra_replay(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("mantra-replay")
     yield from setup_custom_mantra(
-        path, 26400, Path(__file__).parent / "configs/default.jsonnet"
+        path,
+        26400,
+        Path(__file__).parent / "configs/default.jsonnet",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_rollback.py
+++ b/integration_tests/test_rollback.py
@@ -37,7 +37,8 @@ def post_init(broken_binary):
 
 
 @pytest.fixture(scope="module")
-def custom_mantra(tmp_path_factory):
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     path = tmp_path_factory.mktemp("rollback")
 
     cmd = [
@@ -58,6 +59,7 @@ def custom_mantra(tmp_path_factory):
         Path(__file__).parent / "configs/rollback.jsonnet",
         post_init=post_init(broken_binary),
         wait_port=False,
+        chain=chain,
     )
 
 

--- a/integration_tests/test_subscribe.py
+++ b/integration_tests/test_subscribe.py
@@ -134,11 +134,12 @@ def test_subscribe_basic(mantra: Mantra):
         iterations = 10000
         tx = contract.functions.test(iterations).build_transaction()
         raw_transactions = []
-        for key_from in KEYS.values():
-            signed = sign_transaction(w3, tx, key_from)
-            raw_transactions.append(signed.raw_transaction)
+        for key in KEYS.values():
+            if key != "reserve":
+                signed = sign_transaction(w3, tx, key)
+                raw_transactions.append(signed.raw_transaction)
         send_raw_transactions(w3, raw_transactions)
-        total = len(KEYS) * iterations
+        total = len(raw_transactions) * iterations
         msgs = [await c.recv_subscription(sub_id) for i in range(total)]
         assert len(msgs) == total
         assert all(msg["topics"] == [f"0x{TEST_EVENT_TOPIC.hex()}"] for msg in msgs)

--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -32,9 +32,14 @@ pytestmark = pytest.mark.slow
 
 
 @pytest.fixture(scope="module")
-def custom_mantra(tmp_path_factory):
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     yield from setup_mantra_upgrade(
-        tmp_path_factory, "upgrade-test-package", "cosmovisor", "genesis"
+        tmp_path_factory,
+        "upgrade-test-package",
+        "cosmovisor",
+        "genesis",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_upgrade_recent.py
+++ b/integration_tests/test_upgrade_recent.py
@@ -24,9 +24,14 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture(scope="module")
-def custom_mantra(tmp_path_factory):
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     yield from setup_mantra_upgrade(
-        tmp_path_factory, "upgrade-test-package", "cosmovisor_recent", "v5.0.0-rc3"
+        tmp_path_factory,
+        "upgrade-test-package",
+        "cosmovisor_recent",
+        "v5.0.0-rc3",
+        chain=chain,
     )
 
 

--- a/integration_tests/test_upgrade_unify.py
+++ b/integration_tests/test_upgrade_unify.py
@@ -26,9 +26,14 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture(scope="module")
-def custom_mantra(tmp_path_factory):
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
     yield from setup_mantra_upgrade(
-        tmp_path_factory, "upgrade-test-package", "cosmovisor", "genesis"
+        tmp_path_factory,
+        "upgrade-test-package",
+        "cosmovisor",
+        "genesis",
+        chain=chain,
     )
 
 

--- a/integration_tests/upgrade_utils.py
+++ b/integration_tests/upgrade_utils.py
@@ -86,7 +86,7 @@ def post_init(path, base_port, config, genesis):
     )
 
 
-def setup_mantra_upgrade(tmp_path_factory, nix_name, cfg_name, genesis):
+def setup_mantra_upgrade(tmp_path_factory, nix_name, cfg_name, genesis, chain):
     path = tmp_path_factory.mktemp("upgrade")
     port = 26200
     configdir = Path(__file__).parent
@@ -115,6 +115,7 @@ def setup_mantra_upgrade(tmp_path_factory, nix_name, cfg_name, genesis):
         post_init=post_init,
         chain_binary=str(upgrades / f"{genesis}/bin/mantrachaind"),
         genesis=genesis,
+        chain=chain,
     ) as mantra:
         yield mantra
 

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -57,7 +57,7 @@ ADDRS = {name: account.address for name, account in ACCOUNTS.items()}
 
 DEFAULT_DENOM = "uom"
 CHAIN_ID = os.getenv("CHAIN_ID", "mantra-canary-net-1")
-EVM_CHAIN_ID = os.getenv("EVM_CHAIN_ID", 5887)
+EVM_CHAIN_ID = int(os.getenv("EVM_CHAIN_ID", 5887))
 # the default initial base fee used by integration tests
 DEFAULT_GAS_AMT = 0.01
 DEFAULT_GAS_PRICE = f"{DEFAULT_GAS_AMT}{DEFAULT_DENOM}"


### PR DESCRIPTION
Closes: #54

Solution:
- add cli flag to specify custom binary to use

## Usage

Put `evmd` on `PATH` and run:

```
$ pytest integration_tests -s -k test_simple --chain-config evmd
```

But test cases needs to adapt if run against EVM main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * New pytest CLI option (--chain-config) to select chain configs at runtime.
  * Test fixtures and network/setup flows accept and propagate the selected chain, producing chain-specific configs (from jsonnet) before launching test networks.
  * Many tests updated to support configurable chains while preserving default behavior.
  * Test utilities now coerce EVM chain ID to a numeric value.

* **Documentation**
  * Example added showing how to run tests with --chain-config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->