### PR TITLE
Problem: parse chain id for evm chain id is not tested

### DIFF
--- a/integration_tests/configs/chain-id.jsonnet
+++ b/integration_tests/configs/chain-id.jsonnet
@@ -1,0 +1,13 @@
+local config = import 'default.jsonnet';
+local chain_id = 'mantra_9001-1';
+
+config {
+  'mantra-canary-net-1'+: {
+    client_config+: {
+      'chain-id': chain_id,
+    },
+    genesis+: {
+      chain_id+: chain_id,
+    },
+  },
+}

--- a/integration_tests/configs/chains.jsonnet
+++ b/integration_tests/configs/chains.jsonnet
@@ -2,7 +2,6 @@
   evmd: {
     evm_denom: 'atest',
     cmd: 'evmd',
-    chain_id: 9001,
     evm_chain_id: 262144,
     evm: {},
     feemarket: {
@@ -15,7 +14,6 @@
   mantrachaind: {
     evm_denom: 'uom',
     cmd: 'mantrachaind',
-    chain_id: 'mantra-canary-net-1',
     evm_chain_id: 7888,
     evm: {
       params: {

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -11,7 +11,6 @@ local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
       },
     },
     'app-config': {
-      chain_id: 'mantra-canary-net-1',
       evm: {
         'evm-chain-id': chain.evm_chain_id,
       },

--- a/integration_tests/poetry.lock
+++ b/integration_tests/poetry.lock
@@ -1927,8 +1927,8 @@ tomlkit = "^0"
 [package.source]
 type = "git"
 url = "https://github.com/MANTRA-Chain/pystarport.git"
-reference = "client_id"
-resolved_reference = "2f6a51ca9d3a76e57348a4d9b624b185499b17a3"
+reference = "app_config"
+resolved_reference = "5537ab7ada7eb91ff168fb9575fb9be342ad0c52"
 
 [[package]]
 name = "pytest"
@@ -2787,4 +2787,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "cac17c575103c0747438d9ad3738e964d432dd5cd1e3eb550cd51c79d8c7b7e2"
+content-hash = "e399be5b7d40eeec5d5f99694d0be19830a430b3ac7125eb6d08ac3485296ca2"

--- a/integration_tests/poetry.lock
+++ b/integration_tests/poetry.lock
@@ -1927,8 +1927,8 @@ tomlkit = "^0"
 [package.source]
 type = "git"
 url = "https://github.com/MANTRA-Chain/pystarport.git"
-reference = "app_config"
-resolved_reference = "060561102b285667ac41ceeb2e3738cc59133a54"
+reference = "client_id"
+resolved_reference = "2f6a51ca9d3a76e57348a4d9b624b185499b17a3"
 
 [[package]]
 name = "pytest"
@@ -2787,4 +2787,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e399be5b7d40eeec5d5f99694d0be19830a430b3ac7125eb6d08ac3485296ca2"
+content-hash = "cac17c575103c0747438d9ad3738e964d432dd5cd1e3eb550cd51c79d8c7b7e2"

--- a/integration_tests/pyproject.toml
+++ b/integration_tests/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.12"
 pytest = "^8.3.4"
-pystarport = { git = "https://github.com/MANTRA-Chain/pystarport.git", branch = "client_id" }
+pystarport = { git = "https://github.com/MANTRA-Chain/pystarport.git", branch = "app_config" }
 pytest-github-actions-annotate-failures = "^0.3.0"
 flake8-black = "^0.3.6"
 flake8-isort = "^6.1.2"

--- a/integration_tests/pyproject.toml
+++ b/integration_tests/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.12"
 pytest = "^8.3.4"
-pystarport = { git = "https://github.com/MANTRA-Chain/pystarport.git", branch = "app_config" }
+pystarport = { git = "https://github.com/MANTRA-Chain/pystarport.git", branch = "client_id" }
 pytest-github-actions-annotate-failures = "^0.3.0"
 flake8-black = "^0.3.6"
 flake8-isort = "^6.1.2"

--- a/integration_tests/test_chain_id.py
+++ b/integration_tests/test_chain_id.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+from eth_contract.utils import send_transaction
+
+from .network import setup_custom_mantra
+from .utils import ACCOUNTS, ADDRS
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(scope="module")
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
+    path = tmp_path_factory.mktemp("chain-id")
+    yield from setup_custom_mantra(
+        path,
+        26600,
+        Path(__file__).parent / "configs/chain-id.jsonnet",
+        chain=chain,
+    )
+
+
+async def test_chain_id(custom_mantra):
+    w3 = custom_mantra.async_w3
+    assert await w3.eth.chain_id == 9001
+    tx = {"to": ADDRS["signer1"], "value": 1000}
+    await send_transaction(w3, ACCOUNTS["community"], **tx)

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,8 +84,8 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "956614f44e67ad92cf3ea07661bd29dbd8d1f6d7";
-    hash = "sha256-4H4iom0uOlyw+PktvSbHXNXd0ivdkpFNu5miiRPLPHY=";
+    rev = "9bb277a24c6fce7c22a9ecf021bd718dbb1413d1";
+    hash = "sha256-KCFPAdpfMu0UHJsrdjFv9wd2uzHH4S1z4r7SqJdA4P8=";
   };
   vendorHash = "sha256-g+0SmUomCtZ/95I5qKgVtptjgWJL/v6v2zx1ksIok3A=";
   proxyVendor = true;


### PR DESCRIPTION
depends on https://github.com/MANTRA-Chain/pystarport/pull/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test validating chain ID exposure (9001) and a basic transaction on a custom canary network configuration.
  * Introduced a dedicated config for chain ID and streamlined related test configs.

* **Chores**
  * Updated MANTRA-Chain dependency to a newer upstream revision for builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->