### PR TITLE
Problem: rc9 upgrade is not tested

### DIFF
--- a/integration_tests/configs/mantrachain-common.nix
+++ b/integration_tests/configs/mantrachain-common.nix
@@ -79,6 +79,14 @@ let
         linux-amd64 = "sha256-5JoSVg9FGkbuMTlEQsvllIPyIZwaDGzzog5JJxr/6IY=";
       };
     };
+    "v5.0.0-rc8" = {
+      filename = "mantrachaind-5.0.0-rc8-${platform}.tar.gz";
+      sha256 = {
+        darwin-amd64 = "sha256-Pz8hum/wPHTnIBxN+xxdluEsfEKtFMeY2NaJa7Bwzg4=";
+        linux-arm64 = "sha256-wYd+I+qfZNRrwiTy3wGnC/W8Zt+AUD5nsXy9habkzy8=";
+        linux-amd64 = "sha256-wYd+I+qfZNRrwiTy3wGnC/W8Zt+AUD5nsXy9habkzy8=";
+      };
+    };
   };
 
   mkMantrachain = { version, name ? "mantrachaind-${version}" }: 

--- a/integration_tests/configs/upgrade-test-package.nix
+++ b/integration_tests/configs/upgrade-test-package.nix
@@ -12,17 +12,18 @@ let
     "v5.0.0-rc5" = common.mkMantrachain { version = "v5.0.0-rc5"; };
     "v5.0.0-rc6" = common.mkMantrachain { version = "v5.0.0-rc6"; };
     "v5.0.0-rc7" = common.mkMantrachain { version = "v5.0.0-rc7"; };
+    "v5.0.0-rc8" = common.mkMantrachain { version = "v5.0.0-rc8"; };
   } // (
     pkgs.lib.optionalAttrs includeMantrachaind {
       "v5.0" = pkgs.callPackage ../../nix/mantrachain { };
-      "v5.0.0-rc8" = pkgs.callPackage ../../nix/mantrachain { };
+      "v5.0.0-rc9" = pkgs.callPackage ../../nix/mantrachain { };
     }
   ) // (
     pkgs.lib.optionalAttrs (!includeMantrachaind) {
       "v5.0" = pkgs.writeShellScriptBin "mantrachaind" ''
         exec mantrachaind "$@"
       '';
-      "v5.0.0-rc8" = pkgs.writeShellScriptBin "mantrachaind" ''
+      "v5.0.0-rc9" = pkgs.writeShellScriptBin "mantrachaind" ''
         exec mantrachaind "$@"
       '';
     }

--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -238,6 +238,12 @@ def exec(c, tmp_path):
     wait_for_new_blocks(cli, 1)
     check_basic_eth_tx(c.w3, contract, acc_b, addr_a, "world rc8")
 
+    height = cli.block_height()
+    target_height = height + 15
+
+    cli = do_upgrade(c, "v5.0.0-rc9", target_height, gas_prices=DEFAULT_GAS_PRICE)
+    check_basic_eth_tx(c.w3, contract, acc_b, addr_a, "world rc9")
+
 
 def test_cosmovisor_upgrade(custom_mantra: Mantra, tmp_path):
     exec(custom_mantra, tmp_path)

--- a/integration_tests/test_upgrade_recent.py
+++ b/integration_tests/test_upgrade_recent.py
@@ -115,6 +115,11 @@ async def exec(c):
 
     cli = do_upgrade(c, "v5.0.0-rc8", target_height)
 
+    height = cli.block_height()
+    target_height = height + 15
+
+    cli = do_upgrade(c, "v5.0.0-rc9", target_height)
+
 
 async def test_cosmovisor_upgrade(custom_mantra: Mantra):
     await exec(custom_mantra)

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,8 +84,8 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "8dc83ce9ba8b1cdb43f33e2ff32c9140acf3ad34";
-    hash = "sha256-KJe/28/0lbXnehaNiBZnVb6jUdZDYzTQyJtxN+4LcC8=";
+    rev = "cef42e79e72cabea6cb0b191222c982a8171d9da";
+    hash = "sha256-hhgQ2/rt5JouHj83c16lrdea1pDC64JQoTBmjw+4OdY=";
   };
   vendorHash = "sha256-g+0SmUomCtZ/95I5qKgVtptjgWJL/v6v2zx1ksIok3A=";
   proxyVendor = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for MANTRA Chain v5.0.0-rc8 artifacts across macOS and Linux platforms.

- Chores
  - Updated underlying MANTRA Chain source to a newer revision.
  - Adjusted upgrade configuration to target v5.0.0-rc9 where applicable.

- Tests
  - Extended upgrade scenarios to include a step from rc8 to rc9 using a block-height target.
  - Added post-upgrade transaction validation to confirm network functionality after rc9 deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->