### PR TITLE
Problem: read chain ID from app.toml before genesis is not tested

### DIFF
--- a/integration_tests/configs/chain-id.jsonnet
+++ b/integration_tests/configs/chain-id.jsonnet
@@ -9,5 +9,10 @@ config {
     genesis+: {
       chain_id+: chain_id,
     },
+    'app-config'+: {
+      evm+: {
+        'evm-chain-id': 9001,
+      },
+    },
   },
 }

--- a/integration_tests/configs/ibc.jsonnet
+++ b/integration_tests/configs/ibc.jsonnet
@@ -44,7 +44,7 @@ config {
   'mantra-canary-net-1'+: common {
     key_name: 'signer1',
   },
-  'mantra-1'+: basic + common {
+  'mantra-canary-net-2'+: basic + common {
     key_name: 'signer2',
     validators: [validator {
       base_port: 26800 + i * 10,
@@ -78,7 +78,7 @@ config {
         id: 'mantra-canary-net-1',
       },
       rly {
-        id: 'mantra-1',
+        id: 'mantra-canary-net-2',
       },
     ],
   },

--- a/integration_tests/ibc_utils.py
+++ b/integration_tests/ibc_utils.py
@@ -37,7 +37,7 @@ def call_hermes_cmd(hermes, incentivized, version):
             "--a-chain",
             CHAIN_ID,
             "--b-chain",
-            "mantra-1",
+            "mantra-canary-net-2",
             "--new-client-connection",
             "--yes",
         ]
@@ -62,7 +62,7 @@ def prepare_network(tmp_path, name, chain):
         chain=chain,
     ) as ibc1:
         cli = ibc1.cosmos_cli()
-        ibc2 = Mantra(ibc1.base_dir.parent / "mantra-1")
+        ibc2 = Mantra(ibc1.base_dir.parent / "mantra-canary-net-2")
         # wait for grpc ready
         wait_for_port(ports.grpc_port(ibc2.base_port(0)))
         wait_for_port(ports.grpc_port(ibc1.base_port(0)))

--- a/integration_tests/test_ibc.py
+++ b/integration_tests/test_ibc.py
@@ -123,9 +123,9 @@ async def test_ibc_transfer(ibc):
     signer2 = ADDRS["signer2"]
     addr_signer1 = eth_to_bech32(signer1)
 
-    # mantra-1 signer2 -> mantra-canary-net-1 signer1 100uom
+    # mantra-canary-net-2 signer2 -> mantra-canary-net-1 signer1 100uom
     transfer_amt = 100
-    src_chain = "mantra-1"
+    src_chain = "mantra-canary-net-2"
     dst_chain = "mantra-canary-net-1"
     path, escrow_addr = hermes_transfer(
         ibc, src_chain, dst_chain, transfer_amt, addr_signer1
@@ -185,10 +185,10 @@ async def test_ibc_cb(ibc, tmp_path):
     # check native erc20 transfer
     assert_register_erc20_denom(ibc.ibc1, WETH_ADDRESS, tmp_path)
 
-    # mantra-canary-net-1 signer1 -> mantra-1 signer2 50erc20_denom
+    # mantra-canary-net-1 signer1 -> mantra-canary-net-2 signer2 50erc20_denom
     transfer_amt = total // 2
     src_chain = "mantra-canary-net-1"
-    dst_chain = "mantra-1"
+    dst_chain = "mantra-canary-net-2"
     channel = "channel-0"
     isolated = generate_isolated_address(channel, addr_signer2)
 
@@ -228,8 +228,8 @@ async def test_ibc_cb(ibc, tmp_path):
     cb_contract, dest_cb = await prepare_dest_callback(w3, signer1, transfer_amt)
     cb_balance_bf = await ERC20.fns.balanceOf(cb_contract).call(w3, to=WETH_ADDRESS)
 
-    # mantra-1 signer2 -> mantra-canary-net-1 signer1 50erc20_denom
-    src_chain = "mantra-1"
+    # mantra-canary-net-2 signer2 -> mantra-canary-net-1 signer1 50erc20_denom
+    src_chain = "mantra-canary-net-2"
     dst_chain = "mantra-canary-net-1"
     hermes_transfer(
         ibc, src_chain, dst_chain, transfer_amt, isolated, denom=dst_denom, memo=dest_cb

--- a/integration_tests/test_statesync.py
+++ b/integration_tests/test_statesync.py
@@ -7,6 +7,7 @@ from pystarport import cluster, ports
 
 from .utils import (
     ADDRS,
+    EVM_CHAIN_ID,
     Greeter,
     get_sync_info,
     send_transaction,
@@ -51,6 +52,9 @@ def test_statesync(mantra):
         clustercli.home(i) / "config/app.toml",
         clustercli.base_port(i),
         {
+            "evm": {
+                "evm-chain-id": EVM_CHAIN_ID,
+            },
             "json-rpc": {
                 "enable": True,
                 "address": "127.0.0.1:{EVMRPC_PORT}",

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,10 +84,10 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "8ef41dbcd9233be4c640af3db418557f06cbe655";
-    hash = "sha256-CSv5aqQUJnagWUZipsY29869lk6r4mY7wduzzNdSA4s=";
+    rev = "292f01da6415183dfd28a615a1eed2ee8f4e13c8";
+    hash = "sha256-DgTV7EMM92KFILRg5Nd3ZarLczZhGxGy7b8DTNw6Fyo=";
   };
-  vendorHash = "sha256-g+0SmUomCtZ/95I5qKgVtptjgWJL/v6v2zx1ksIok3A=";
+  vendorHash = "sha256-BOYJVYrS9PjgD7MQ+fL9GjDh3b4212RkBHC/12POE10=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";


### PR DESCRIPTION
test https://github.com/MANTRA-Chain/mantrachain/pull/454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Updated IBC tests to use mantra-canary-net-2 and adjusted source/destination chain identifiers.
  - Statesync tests now configure a node with an EVM chain ID for JSON-RPC/EVM endpoints.

- Chores
  - Updated IBC config and relayer references to mantra-canary-net-2 and aligned tooling/actions accordingly.
  - Bumped mantrachain source to a newer revision with updated verification hashes.
  - Added public app-config to set evm-chain-id (9001) for mantra-canary-net-1.

- Impact
  - Keeps tests, tooling, and test node configs aligned with current network naming and EVM settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->