### PR TITLE
Problem: ibc transfer tf fix is not tested

### DIFF
--- a/integration_tests/configs/mantrachain-common.nix
+++ b/integration_tests/configs/mantrachain-common.nix
@@ -63,6 +63,22 @@ let
         linux-amd64 = "sha256-wYd+I+qfZNRrwiTy3wGnC/W8Zt+AUD5nsXy9habkzy8=";
       };
     };
+    "v5.0.0-rc9" = {
+      filename = "mantrachaind-5.0.0-rc9-${platform}.tar.gz";
+      sha256 = {
+        darwin-amd64 = "sha256-87ZFkqmSbI5RcVvSMAKOCc72hzrbgDKtlC/vG4Tq9XI=";
+        linux-arm64 = "sha256-JPYm3zjf+5wDVydhglDfXrlCm9apCXIfUsfQ4O7jfhw=";
+        linux-amd64 = "sha256-JPYm3zjf+5wDVydhglDfXrlCm9apCXIfUsfQ4O7jfhw=";
+      };
+    };
+    "v5.0.0" = {
+      filename = "mantrachaind-5.0.0-${platform}.tar.gz";
+      sha256 = {
+        darwin-amd64 = "sha256-PUXb9BG6/Dao7fvC0btOtPJhGAMDi74P6sG7zkkzKQY=";
+        linux-arm64 = "sha256-2kyy5wegogsWHD4ntI+oFxTTu0ATq2iLPxJ8ahUjejY=";
+        linux-amd64 = "sha256-2kyy5wegogsWHD4ntI+oFxTTu0ATq2iLPxJ8ahUjejY=";
+      };
+    };
   };
 
   mkMantrachain = { version, name ? "mantrachaind-${version}" }: 

--- a/integration_tests/configs/upgrade-test-package.nix
+++ b/integration_tests/configs/upgrade-test-package.nix
@@ -10,17 +10,15 @@ let
     "v5.0.0-rc6" = common.mkMantrachain { version = "v5.0.0-rc6"; };
     "v5.0.0-rc7" = common.mkMantrachain { version = "v5.0.0-rc7"; };
     "v5.0.0-rc8" = common.mkMantrachain { version = "v5.0.0-rc8"; };
+    "v5.0" = common.mkMantrachain { version = "v5.0.0"; };
+    "v5.0.0-rc9" = common.mkMantrachain { version = "v5.0.0-rc9"; };
   } // (
     pkgs.lib.optionalAttrs includeMantrachaind {
-      "v5.0" = pkgs.callPackage ../../nix/mantrachain { };
-      "v5.0.0-rc9" = pkgs.callPackage ../../nix/mantrachain { };
+      "v6.0.0-rc0" = pkgs.callPackage ../../nix/mantrachain { };
     }
   ) // (
     pkgs.lib.optionalAttrs (!includeMantrachaind) {
-      "v5.0" = pkgs.writeShellScriptBin "mantrachaind" ''
-        exec mantrachaind "$@"
-      '';
-      "v5.0.0-rc9" = pkgs.writeShellScriptBin "mantrachaind" ''
+      "v6.0.0-rc0" = pkgs.writeShellScriptBin "mantrachaind" ''
         exec mantrachaind "$@"
       '';
     }

--- a/integration_tests/test_ibc.py
+++ b/integration_tests/test_ibc.py
@@ -193,13 +193,11 @@ async def test_ibc_transfer(ibc):
 
         return await wait_for_fn_async("balance change", check_balance)
 
-    cb_balance = await wait_for_balance_change_async(
+    balance_af = await wait_for_balance_change_async(
         w3, signer1, tf_erc20_addr, balance_bf
     )
-    assert cb_balance == balance_bf + transfer_amt
-    assert cli2.balance(addr_signer2, dst_denom) == 0
-    balance_af = await ERC20.fns.balanceOf(signer1).call(w3, to=tf_erc20_addr)
     assert balance_af == cli.balance(addr_signer1, denom) == balance_bf + transfer_amt
+    assert cli2.balance(addr_signer2, dst_denom) == 0
 
 
 async def prepare_dest_callback(w3, sender, amt):

--- a/integration_tests/test_ibc.py
+++ b/integration_tests/test_ibc.py
@@ -112,6 +112,7 @@ async def assert_tokenfactory_flow(cli, w3, signer1, receiver):
     balance = cli.balance(addr_receiver, denom)
     signer1_balance_eth = await ERC20.fns.balanceOf(receiver).call(w3, to=tf_erc20_addr)
     assert balance == signer1_balance_eth == transfer_amt
+    return denom
 
 
 async def test_ibc_transfer(ibc):
@@ -120,6 +121,7 @@ async def test_ibc_transfer(ibc):
     cli2 = ibc.ibc2.cosmos_cli()
     signer1 = ADDRS["signer1"]
     signer2 = ADDRS["signer2"]
+    addr_signer2 = eth_to_bech32(signer2)
     addr_signer1 = eth_to_bech32(signer1)
 
     # mantra-canary-net-2 signer2 -> mantra-canary-net-1 signer1 100uom
@@ -149,7 +151,25 @@ async def test_ibc_transfer(ibc):
     # check the approve transfer and transferFrom flow of tf tokens
     await assert_tf_flow(w3, receiver, signer1, signer2, ibc_erc20_addr)
     # check create mint transfer and burn tokenfactory denom
-    await assert_tokenfactory_flow(cli, w3, signer1, receiver)
+    denom = await assert_tokenfactory_flow(cli, w3, signer1, receiver)
+
+    # mantra-canary-net-1 signer1 -> mantra-canary-net-2 signer2 50 tf_token
+    transfer_amt = 50
+    src_chain = "mantra-canary-net-1"
+    dst_chain = "mantra-canary-net-2"
+
+    path, escrow_addr = hermes_transfer(
+        ibc, src_chain, dst_chain, transfer_amt, addr_signer2, denom=denom
+    )
+    denom_hash = hashlib.sha256(path.encode()).hexdigest().upper()
+    dst_denom = f"ibc/{denom_hash}"
+    signer2_balance_bf = cli2.balance(addr_signer2, dst_denom)
+    signer2_balance = wait_for_balance_change(
+        cli2, addr_signer2, dst_denom, signer2_balance_bf
+    )
+    assert signer2_balance == signer2_balance_bf + transfer_amt
+    assert cli2.ibc_denom_hash(path) == denom_hash
+    signer2_balance_bf = signer2_balance
 
 
 async def prepare_dest_callback(w3, sender, amt):

--- a/integration_tests/test_ibc.py
+++ b/integration_tests/test_ibc.py
@@ -112,7 +112,7 @@ async def assert_tokenfactory_flow(cli, w3, signer1, receiver):
     balance = cli.balance(addr_receiver, denom)
     signer1_balance_eth = await ERC20.fns.balanceOf(receiver).call(w3, to=tf_erc20_addr)
     assert balance == signer1_balance_eth == transfer_amt
-    return denom
+    return denom, tf_erc20_addr
 
 
 async def test_ibc_transfer(ibc):
@@ -151,7 +151,7 @@ async def test_ibc_transfer(ibc):
     # check the approve transfer and transferFrom flow of tf tokens
     await assert_tf_flow(w3, receiver, signer1, signer2, ibc_erc20_addr)
     # check create mint transfer and burn tokenfactory denom
-    denom = await assert_tokenfactory_flow(cli, w3, signer1, receiver)
+    denom, tf_erc20_addr = await assert_tokenfactory_flow(cli, w3, signer1, receiver)
 
     # mantra-canary-net-1 signer1 -> mantra-canary-net-2 signer2 50 tf_token
     transfer_amt = 50
@@ -170,6 +170,36 @@ async def test_ibc_transfer(ibc):
     assert signer2_balance == signer2_balance_bf + transfer_amt
     assert cli2.ibc_denom_hash(path) == denom_hash
     signer2_balance_bf = signer2_balance
+
+    # mantra-canary-net-2 signer2 -> mantra-canary-net-1 signer1 50 tf_token
+    balance_bf = await ERC20.fns.balanceOf(signer1).call(w3, to=tf_erc20_addr)
+    assert balance_bf == cli.balance(addr_signer1, denom)
+    src_chain = "mantra-canary-net-2"
+    dst_chain = "mantra-canary-net-1"
+    hermes_transfer(
+        ibc,
+        src_chain,
+        dst_chain,
+        transfer_amt,
+        addr_signer1,
+        denom=dst_denom,
+    )
+    assert cli2.balance(addr_signer2, dst_denom) == signer2_balance_bf - transfer_amt
+
+    async def wait_for_balance_change_async(w3, addr, token_addr, init_balance):
+        async def check_balance():
+            current_balance = await ERC20.fns.balanceOf(addr).call(w3, to=token_addr)
+            return current_balance if current_balance != init_balance else None
+
+        return await wait_for_fn_async("balance change", check_balance)
+
+    cb_balance = await wait_for_balance_change_async(
+        w3, signer1, tf_erc20_addr, balance_bf
+    )
+    assert cb_balance == balance_bf + transfer_amt
+    assert cli2.balance(addr_signer2, dst_denom) == 0
+    balance_af = await ERC20.fns.balanceOf(signer1).call(w3, to=tf_erc20_addr)
+    assert balance_af == cli.balance(addr_signer1, denom) == balance_bf + transfer_amt
 
 
 async def prepare_dest_callback(w3, sender, amt):

--- a/integration_tests/test_sanction.py
+++ b/integration_tests/test_sanction.py
@@ -20,6 +20,7 @@ from .utils import (
 pytestmark = pytest.mark.slow
 
 
+@pytest.mark.flaky(max_runs=2)
 def test_blacklist(mantra, tmp_path):
     cli = mantra.cosmos_cli()
     community = cli.address("community")

--- a/integration_tests/test_upgrade_recent.py
+++ b/integration_tests/test_upgrade_recent.py
@@ -110,6 +110,13 @@ async def exec(c):
 
     cli = do_upgrade(c, "v5.0.0-rc9", target_height)
 
+    height = cli.block_height()
+    target_height = height + 15
+    cli = do_upgrade(c, "v6.0.0-rc0", target_height)
+
+    pair = cli.query_erc20_token_pair(denom)
+    assert pair["contract_owner"] == "OWNER_MODULE"
+
 
 async def test_cosmovisor_upgrade(custom_mantra: Mantra):
     await exec(custom_mantra)

--- a/integration_tests/test_upgrade_unify.py
+++ b/integration_tests/test_upgrade_unify.py
@@ -1,19 +1,12 @@
-import json
-import re
-import subprocess
 import time
-from pathlib import Path
 
 import pytest
-import tomlkit
 from eth_contract.erc20 import ERC20
-from pystarport import cluster, ports
 
 from .network import Mantra
 from .upgrade_utils import (
     cleanup_upgrades_folder,
     do_upgrade,
-    patch_app_evm_chain_ids,
     setup_mantra_upgrade,
 )
 from .utils import (
@@ -28,10 +21,7 @@ from .utils import (
     denom_to_erc20_address,
     derive_new_account,
     eth_to_bech32,
-    get_sync_info,
-    wait_for_block,
     wait_for_new_blocks,
-    wait_for_port,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -70,58 +60,6 @@ async def exec(c, tmp_path):
     )
 
     cli = do_upgrade(c, "v5.0", target_height)
-
-    data = Path(c.base_dir).parent
-    chain_id = c.config["chain_id"]
-    clustercli = cluster.ClusterCLI(data, cmd="mantrachaind", chain_id=chain_id)
-    i = clustercli.create_node(moniker="statesync", statesync=True)
-    # Modify the json-rpc addresses to avoid conflict
-    cluster.edit_app_cfg(
-        clustercli.home(i) / "config/app.toml",
-        clustercli.base_port(i),
-        {
-            "json-rpc": {
-                "enable": True,
-                "address": "127.0.0.1:{EVMRPC_PORT}",
-                "ws-address": "127.0.0.1:{EVMRPC_PORT_WS}",
-            },
-        },
-    )
-    clustercli.supervisor.startProcess(f"{clustercli.chain_id}-node{i}")
-    # Wait 1 more block
-    wait_for_block(clustercli.cosmos_cli(i), cli.block_height() + 1)
-    time.sleep(1)
-
-    # check query chain state works
-    assert not get_sync_info(clustercli.status(i))["catching_up"]
-    wait_for_port(ports.evmrpc_port(clustercli.base_port(i)))
-
-    print(c.supervisorctl("stop", "all"))
-    time.sleep(5)
-    patch_app_evm_chain_ids(c)
-
-    config_dir = clustercli.cosmos_cli(i).data_dir / "config"
-    patch_chain_id(config_dir)
-    patch_genesis(config_dir, "mantra-test-1")
-
-    ini = c.base_dir / "tasks.ini"
-    cmd = "command = mantrachaind start --home . --trace --chain-id mantra-canary-net-1"
-    ini.write_text(
-        re.sub(
-            r"^command = mantrachaind start --home .$",
-            cmd,
-            ini.read_text(),
-            flags=re.M,
-        )
-    )
-    c.supervisorctl("update")
-    nodes = [f"mantra-canary-net-1-node{i}" for i in range(4)]
-    with pytest.raises(subprocess.CalledProcessError):
-        c.supervisorctl("start", *nodes)
-
-    patch_genesis(config_dir, "mantra-canary-net-1")
-    c.supervisorctl("start", *nodes)
-    wait_for_new_blocks(cli, 1)
 
     # check set contract tx works
     acc_c = derive_new_account(101)
@@ -169,24 +107,14 @@ async def exec(c, tmp_path):
     balance_eth = await ERC20.fns.balanceOf(receiver).call(w3, to=tf_erc20_addr)
     assert balance == balance_eth == transfer_amt2
 
-    # check sync node health
-    assert abs(clustercli.cosmos_cli(i).block_height() - cli.block_height()) <= 1
+    height = cli.block_height()
+    target_height = height + 15
+    cli = do_upgrade(c, "v6.0.0-rc0", target_height)
+
+    pair = cli.query_erc20_token_pair(denom)
+    assert pair["contract_owner"] == "OWNER_MODULE"
 
 
 async def test_cosmovisor_upgrade(custom_mantra: Mantra, tmp_path):
     await exec(custom_mantra, tmp_path)
     cleanup_upgrades_folder(custom_mantra.cosmos_cli().data_dir)
-
-
-def patch_chain_id(path):
-    cfg_file = path / "app.toml"
-    cfg = tomlkit.parse(cfg_file.read_text())
-    cfg["evm"] = {}
-    cfg_file.write_text(tomlkit.dumps(cfg))
-
-
-def patch_genesis(path, chain_id):
-    genesis_path = path / "genesis.json"
-    genesis = json.loads(genesis_path.read_text())
-    genesis["chain_id"] = chain_id
-    genesis_path.write_text(json.dumps(genesis, indent=2))

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -579,7 +579,7 @@ def assert_create_tokenfactory_denom(cli, subdenom, is_legacy=False, **kwargs):
             "erc20_address": erc20_address,
             "denom": denom,
             "enabled": True,
-            "contract_owner": "OWNER_EXTERNAL",
+            "contract_owner": "OWNER_MODULE",
         }
     assert expected.items() <= event.items()
     meta = {"denom_units": [{"denom": denom}], "base": denom}

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,8 +84,8 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "dec2c862f0ba619d5d221a398a92caa9733e9832";
-    hash = "sha256-+Q3BDRO5E5PZFmIMjXlVN61j74oPzSiUMYCORYKeCHQ=";
+    rev = "9778e445d3fb2f91d0fc00eb282a712a438a4138";
+    hash = "sha256-uthMvYa42MjzLmC5q7pUhv+P7M+Xt0X0KPTFyOOLGcU=";
   };
   vendorHash = "sha256-BOYJVYrS9PjgD7MQ+fL9GjDh3b4212RkBHC/12POE10=";
   proxyVendor = true;

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,8 +84,8 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "9778e445d3fb2f91d0fc00eb282a712a438a4138";
-    hash = "sha256-uthMvYa42MjzLmC5q7pUhv+P7M+Xt0X0KPTFyOOLGcU=";
+    rev = "0ccd1dc68a58c3c675f4caaba96567435475eec5";
+    hash = "sha256-uWR/pHUgY6u+GskEz0E56LoZ2rhTMcTNtzF6cNCeJhg=";
   };
   vendorHash = "sha256-BOYJVYrS9PjgD7MQ+fL9GjDh3b4212RkBHC/12POE10=";
   proxyVendor = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for MANTRA Chain v5.0.0 and v5.0.0-rc9 artifacts, plus preliminary v6.0.0-rc0 upgrade path.
  - Tokenfactory ERC20 pairs now reflect module ownership in metadata after upgrade.

- Tests
  - Expanded IBC E2E: creates new denom, performs round-trip cross-chain transfers, async balance checks, and denom hash validation.
  - Upgrade tests now include a follow-up upgrade to v6.0.0-rc0 and verify module ownership.
  - Marked a flaky sanction test for automatic retries.

- Chores
  - Updated upstream source revision and version catalogs/checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->