### PR TITLE
Problem: static precompiles are not tested

### DIFF
--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -105,6 +105,7 @@ local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
           params+: {
             evm_denom: chain.evm_denom,
             active_static_precompiles: [
+              '0x0000000000000000000000000000000000000800',
               '0x0000000000000000000000000000000000000807',
             ],
           },
@@ -157,6 +158,7 @@ local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
         staking: {
           params: {
             bond_denom: chain.evm_denom,
+            unbonding_time: '10s',
           },
         },
         bank: {

--- a/integration_tests/configs/ibc.jsonnet
+++ b/integration_tests/configs/ibc.jsonnet
@@ -15,6 +15,11 @@ local common = {
           min_gas_price: '0',
         },
       },
+      staking+: {
+        params+: {
+          unbonding_time: '1814400s',
+        },
+      },
     },
   },
 };

--- a/integration_tests/configs/staking.jsonnet
+++ b/integration_tests/configs/staking.jsonnet
@@ -9,6 +9,7 @@ config {
       staked: '10000000000000000000' + chain.evm_denom,
       gas_prices: '0.01' + chain.evm_denom,
       min_self_delegation: 1000000000000000000,
+      mnemonic: '${VALIDATOR4_MNEMONIC}',
     }],
   },
 }

--- a/integration_tests/configs/staking.jsonnet
+++ b/integration_tests/configs/staking.jsonnet
@@ -1,0 +1,14 @@
+local config = import 'default.jsonnet';
+local chain = (import 'chains.jsonnet')[std.extVar('CHAIN_CONFIG')];
+
+config {
+  'mantra-canary-net-1'+: {
+    validators: super.validators + [{
+      'coin-type': 60,
+      coins: '100000000000000000000' + chain.evm_denom,
+      staked: '10000000000000000000' + chain.evm_denom,
+      gas_prices: '0.01' + chain.evm_denom,
+      min_self_delegation: 1000000000000000000,
+    }],
+  },
+}

--- a/integration_tests/cosmoscli.py
+++ b/integration_tests/cosmoscli.py
@@ -359,6 +359,51 @@ class CosmosCLI:
             rsp = self.event_query_tx_for(rsp["txhash"])
         return rsp
 
+    def create_validator(
+        self,
+        amt,
+        options,
+        generate_only=False,
+        **kwargs,
+    ):
+        options = {
+            "commission-max-change-rate": "0.01",
+            "commission-rate": "0.1",
+            "commission-max-rate": "0.2",
+            "min-self-delegation": "1",
+            "amount": amt,
+        } | options
+
+        if "pubkey" not in options:
+            pubkey = (
+                self.raw(
+                    "comet",
+                    "show-validator",
+                    home=self.data_dir,
+                )
+                .strip()
+                .decode()
+            )
+            options["pubkey"] = json.loads(pubkey)
+
+        with tempfile.NamedTemporaryFile("w") as fp:
+            json.dump(options, fp)
+            fp.flush()
+            raw = self.raw(
+                "tx",
+                "staking",
+                "create-validator",
+                fp.name,
+                "-y",
+                "--generate-only" if generate_only else None,
+                "-y",
+                **(self.get_kwargs_with_gas() | kwargs),
+            )
+        rsp = json.loads(raw)
+        if rsp.get("code") == 0:
+            rsp = self.event_query_tx_for(rsp["txhash"])
+        return rsp
+
     def delegation(self, del_addr, val_addr, **kwargs):
         res = json.loads(
             self.raw(

--- a/integration_tests/cosmoscli.py
+++ b/integration_tests/cosmoscli.py
@@ -359,6 +359,56 @@ class CosmosCLI:
             rsp = self.event_query_tx_for(rsp["txhash"])
         return rsp
 
+    def delegation(self, del_addr, val_addr, **kwargs):
+        res = json.loads(
+            self.raw(
+                "q",
+                "staking",
+                "delegation",
+                del_addr,
+                val_addr,
+                **(self.get_base_kwargs() | kwargs),
+            )
+        )
+        return res.get("delegation_response") or res
+
+    def delegations(self, del_addr, **kwargs):
+        res = json.loads(
+            self.raw(
+                "q",
+                "staking",
+                "delegations",
+                del_addr,
+                **(self.get_base_kwargs() | kwargs),
+            )
+        )
+        return res.get("delegation_responses") or res
+
+    def redelegate(
+        self,
+        from_validator,
+        to_validator,
+        amt,
+        generate_only=False,
+        **kwargs,
+    ):
+        rsp = json.loads(
+            self.raw(
+                "tx",
+                "staking",
+                "redelegate",
+                from_validator,
+                to_validator,
+                amt,
+                "--generate-only" if generate_only else None,
+                "-y",
+                **(self.get_kwargs_with_gas() | kwargs),
+            )
+        )
+        if rsp.get("code") == 0:
+            rsp = self.event_query_tx_for(rsp["txhash"])
+        return rsp
+
     def validator(self, addr, **kwargs):
         res = json.loads(
             self.raw(

--- a/integration_tests/cosmoscli.py
+++ b/integration_tests/cosmoscli.py
@@ -126,6 +126,14 @@ class CosmosCLI:
                 raise
         return output.strip().decode()
 
+    def debug_addr(self, eth_addr, bech="acc"):
+        output = self.raw("debug", "addr", eth_addr).decode().strip().split("\n")
+        prefix = "Bech32 Val" if bech == "val" else "Bech32 Acc"
+        for line in output:
+            if line.startswith(prefix):
+                return line.split()[-1]
+        return eth_addr
+
     def account(self, addr, **kwargs):
         return json.loads(
             self.raw("q", "auth", "account", addr, **(self.get_base_kwargs() | kwargs))

--- a/integration_tests/cosmoscli.py
+++ b/integration_tests/cosmoscli.py
@@ -325,7 +325,6 @@ class CosmosCLI:
         return int(res["bonded_tokens" if bonded else "not_bonded_tokens"])
 
     def delegate_amount(self, validator_address, amt, generate_only=False, **kwargs):
-        default_kwargs = self.get_kwargs()
         rsp = json.loads(
             self.raw(
                 "tx",
@@ -335,12 +334,42 @@ class CosmosCLI:
                 amt,
                 "--generate-only" if generate_only else None,
                 "-y",
-                **(default_kwargs | kwargs),
+                **(self.get_kwargs_with_gas() | kwargs),
             )
         )
         if rsp.get("code") == 0:
             rsp = self.event_query_tx_for(rsp["txhash"])
         return rsp
+
+    def unbond_amount(self, to_addr, amt, generate_only=False, **kwargs):
+        rsp = json.loads(
+            self.raw(
+                "tx",
+                "staking",
+                "unbond",
+                to_addr,
+                amt,
+                "-y",
+                "--generate-only" if generate_only else None,
+                "-y",
+                **(self.get_kwargs_with_gas() | kwargs),
+            )
+        )
+        if rsp.get("code") == 0:
+            rsp = self.event_query_tx_for(rsp["txhash"])
+        return rsp
+
+    def validator(self, addr, **kwargs):
+        res = json.loads(
+            self.raw(
+                "q",
+                "staking",
+                "validator",
+                addr,
+                **(self.get_base_kwargs() | kwargs),
+            )
+        )
+        return res.get("validator") or res
 
     def tx_simulate(self, tx, **kwargs):
         default_kwargs = self.get_kwargs()

--- a/integration_tests/poetry.lock
+++ b/integration_tests/poetry.lock
@@ -920,9 +920,9 @@ web3 = ">=7.12.0"
 
 [package.source]
 type = "git"
-url = "https://github.com/yihuang/eth-contract.git"
-reference = "main"
-resolved_reference = "622ece1a539e40da9ea4643fd92b923c26343b5d"
+url = "https://github.com/mmsqe/eth-contract.git"
+reference = "fix_output"
+resolved_reference = "3b2f9fcfeb12807455ec78d43d611be17d5dfe09"
 
 [[package]]
 name = "eth-hash"
@@ -2787,4 +2787,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e399be5b7d40eeec5d5f99694d0be19830a430b3ac7125eb6d08ac3485296ca2"
+content-hash = "49acc7d596ef689b0518ff28b90410a59fb9669f6cd2900c8e022be383b7e4d2"

--- a/integration_tests/pyproject.toml
+++ b/integration_tests/pyproject.toml
@@ -18,7 +18,7 @@ web3 = "^7.3.0"
 eth-bloom = "^3.0"
 flaky = "^3.8.1"
 pytest-asyncio = "0.25.3"
-eth-contract = { git = "https://github.com/yihuang/eth-contract.git", branch = "main" }
+eth-contract = { git = "https://github.com/mmsqe/eth-contract.git", branch = "fix_output" }
 py-ecc = "^8.0.0"
 
 [tool.poetry.dev-dependencies]

--- a/integration_tests/test_staking.py
+++ b/integration_tests/test_staking.py
@@ -1,8 +1,18 @@
+import time
 from datetime import timedelta
+from pathlib import Path
 
 from dateutil.parser import isoparse
+from pystarport import cluster
 
-from .utils import DEFAULT_DENOM, find_fee, find_log_event_attrs, wait_for_block_time
+from .utils import (
+    DEFAULT_DENOM,
+    DEFAULT_GAS_PRICE,
+    find_fee,
+    find_log_event_attrs,
+    wait_for_block,
+    wait_for_block_time,
+)
 
 
 def test_staking_delegate(mantra):
@@ -78,3 +88,65 @@ def test_staking_redelegate(mantra):
     assert rsp["code"] == 0, rsp["raw_log"]
     balance = cli.delegation(signer1, val_ops[0])["balance"]["amount"]
     assert int(balance_bf) == int(balance) + redelegate_amt
+
+
+def test_join_validator(mantra):
+    data = Path(mantra.base_dir).parent
+    chain_id = mantra.config["chain_id"]
+    clustercli = cluster.ClusterCLI(data, cmd="mantrachaind", chain_id=chain_id)
+    moniker = "new joined"
+    node_index = clustercli.create_node(moniker=moniker)
+    cli = clustercli.cosmos_cli(node_index)
+    cli0 = mantra.cosmos_cli()
+    staked = 10_000_000_000_000_000_000
+    fund = f"{staked + 1_000_000}{DEFAULT_DENOM}"
+    val_addr = cli.address("validator", bech="val")
+    addr = cli.address("validator")
+    res = cli0.transfer(cli0.address("community"), addr, fund)
+    assert res["code"] == 0, res
+    # Modify the json-rpc addresses to avoid conflict
+    cluster.edit_app_cfg(
+        clustercli.home(node_index) / "config/app.toml",
+        clustercli.base_port(node_index),
+        {
+            "json-rpc": {
+                "enable": True,
+                "address": "127.0.0.1:{EVMRPC_PORT}",
+                "ws-address": "127.0.0.1:{EVMRPC_PORT_WS}",
+            }
+        },
+    )
+    clustercli.supervisor.startProcess(f"{chain_id}-node{node_index}")
+    wait_for_block(cli, cli0.block_height() + 1)
+    time.sleep(1)
+    wait_for_block(cli, cli.block_height())
+
+    count = len(cli.validators())
+    gas = 420_000
+    opts = {"gas_prices": DEFAULT_GAS_PRICE, "gas": gas}
+    rsp = cli.create_validator(f"{staked}{DEFAULT_DENOM}", {"moniker": moniker}, **opts)
+    if rsp.get("code") == 0:
+        rsp = cli.event_query_tx_for(rsp["txhash"])
+    time.sleep(2)
+    assert len(cli.validators()) == count + 1
+
+    val = cli.validator(val_addr)
+    assert not val.get("jailed")
+    assert val["status"] == "BOND_STATUS_BONDED"
+    assert val["tokens"] == str(staked)
+    assert val["description"]["moniker"] == moniker
+    assert val["commission"]["commission_rates"] == {
+        "rate": "0.100000000000000000",
+        "max_rate": "0.200000000000000000",
+        "max_change_rate": "0.010000000000000000",
+    }
+    rsp = cli.edit_validator(commission_rate="0.2", **opts)
+    if rsp.get("code") == 0:
+        rsp = cli.event_query_tx_for(rsp["txhash"])
+    assert rsp["code"] == 12
+    assert "commission cannot be changed more than once in 24h" in rsp["raw_log"]
+    rsp = cli.edit_validator(new_moniker="awesome node", **opts)
+    if rsp.get("code") == 0:
+        rsp = cli.event_query_tx_for(rsp["txhash"])
+    assert rsp["code"] == 0
+    assert cli.validator(val_addr)["description"]["moniker"] == "awesome node"

--- a/integration_tests/test_staking.py
+++ b/integration_tests/test_staking.py
@@ -1,0 +1,52 @@
+from datetime import timedelta
+
+from dateutil.parser import isoparse
+
+from .utils import DEFAULT_DENOM, find_fee, find_log_event_attrs, wait_for_block_time
+
+
+def test_staking_delegate(mantra):
+    cli = mantra.cosmos_cli()
+    name = "signer1"
+    amt = 2
+    bonded_bf = cli.staking_pool()
+    balance_bf = cli.balance(name)
+    validator = cli.validators()[0]["operator_address"]
+    rsp = cli.delegate_amount(validator, f"{amt}{DEFAULT_DENOM}", _from=name)
+    fee = find_fee(rsp)
+    assert cli.staking_pool() == bonded_bf + amt
+    assert balance_bf == cli.balance(name) + amt + fee
+
+
+def test_staking_unbond(mantra):
+    cli = mantra.cosmos_cli()
+    name = "signer1"
+    signer1 = cli.address(name)
+    validators = cli.validators()
+    val_ops = [v["operator_address"] for v in validators[:2]]
+    balance_bf = cli.balance(signer1)
+    bonded_bf = cli.staking_pool()
+    amounts = [3, 4]
+    fee = 0
+
+    for i, amt in enumerate(amounts):
+        rsp = cli.delegate_amount(val_ops[i], f"{amt}{DEFAULT_DENOM}", _from=name)
+        assert rsp["code"] == 0, rsp["raw_log"]
+        fee += find_fee(rsp)
+
+    assert cli.staking_pool() == bonded_bf + sum(amounts)
+    assert cli.balance(signer1) == balance_bf - sum(amounts) - fee
+
+    unbonded = cli.staking_pool(bonded=False)
+    unbonded_amt = 2
+    rsp = cli.unbond_amount(
+        val_ops[1], f"{unbonded_amt}{DEFAULT_DENOM}", _from=name, gas=220_000
+    )
+    assert rsp["code"] == 0, rsp
+    fee += find_fee(rsp)
+    assert cli.staking_pool(bonded=False) == unbonded + unbonded_amt
+    data = find_log_event_attrs(
+        rsp["events"], "unbond", lambda attrs: "completion_time" in attrs
+    )
+    wait_for_block_time(cli, isoparse(data["completion_time"]) + timedelta(seconds=1))
+    assert cli.balance(signer1) == balance_bf - (sum(amounts) - unbonded_amt) - fee

--- a/integration_tests/test_staking.py
+++ b/integration_tests/test_staking.py
@@ -50,3 +50,31 @@ def test_staking_unbond(mantra):
     )
     wait_for_block_time(cli, isoparse(data["completion_time"]) + timedelta(seconds=1))
     assert cli.balance(signer1) == balance_bf - (sum(amounts) - unbonded_amt) - fee
+
+
+def test_staking_redelegate(mantra):
+    cli = mantra.cosmos_cli()
+    name = "signer1"
+    signer1 = cli.address(name)
+    validators = cli.validators()
+    val_ops = [v["operator_address"] for v in validators[:2]]
+    amounts = [3, 4]
+    fee = 0
+
+    for i, amt in enumerate(amounts):
+        rsp = cli.delegate_amount(val_ops[i], f"{amt}{DEFAULT_DENOM}", _from=name)
+        assert rsp["code"] == 0, rsp["raw_log"]
+        fee += find_fee(rsp)
+
+    balance_bf = cli.delegation(signer1, val_ops[0])["balance"]["amount"]
+    redelegate_amt = 2
+    rsp = cli.redelegate(
+        val_ops[0],
+        val_ops[1],
+        f"{redelegate_amt}{DEFAULT_DENOM}",
+        _from=name,
+        gas=320_000,
+    )
+    assert rsp["code"] == 0, rsp["raw_log"]
+    balance = cli.delegation(signer1, val_ops[0])["balance"]["amount"]
+    assert int(balance_bf) == int(balance) + redelegate_amt

--- a/integration_tests/test_staking.py
+++ b/integration_tests/test_staking.py
@@ -2,9 +2,11 @@ import time
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
 from dateutil.parser import isoparse
 from pystarport import cluster
 
+from .network import setup_custom_mantra
 from .utils import (
     DEFAULT_DENOM,
     DEFAULT_GAS_PRICE,
@@ -12,20 +14,22 @@ from .utils import (
     find_log_event_attrs,
     wait_for_block,
     wait_for_block_time,
+    wait_for_new_blocks,
 )
 
+pytestmark = pytest.mark.slow
 
-def test_staking_delegate(mantra):
-    cli = mantra.cosmos_cli()
-    name = "signer1"
-    amt = 2
-    bonded_bf = cli.staking_pool()
-    balance_bf = cli.balance(name)
-    validator = cli.validators()[0]["operator_address"]
-    rsp = cli.delegate_amount(validator, f"{amt}{DEFAULT_DENOM}", _from=name)
-    fee = find_fee(rsp)
-    assert cli.staking_pool() == bonded_bf + amt
-    assert balance_bf == cli.balance(name) + amt + fee
+
+@pytest.fixture(scope="module")
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
+    path = tmp_path_factory.mktemp("staking")
+    yield from setup_custom_mantra(
+        path,
+        26800,
+        Path(__file__).parent / "configs/staking.jsonnet",
+        chain=chain,
+    )
 
 
 def test_staking_unbond(mantra):
@@ -150,3 +154,19 @@ def test_join_validator(mantra):
         rsp = cli.event_query_tx_for(rsp["txhash"])
     assert rsp["code"] == 0
     assert cli.validator(val_addr)["description"]["moniker"] == "awesome node"
+
+
+def test_min_self_delegation(custom_mantra):
+    cli = custom_mantra.cosmos_cli(i=3)
+    val = cli.address("validator", bech="val")
+    addr = cli.address("validator")
+    gas = 320_000
+    amt = 9_000_000_000_000_000_000
+    assert (
+        cli.unbond_amount(val, f"{amt}{DEFAULT_DENOM}", _from=addr, gas=gas)["code"]
+        == 0
+    )
+    assert cli.validator(val).get("status") == "BOND_STATUS_BONDED"
+    assert cli.unbond_amount(val, f"1{DEFAULT_DENOM}", _from=addr, gas=gas)["code"] == 0
+    wait_for_new_blocks(cli, 2)
+    assert cli.validator(val).get("status") == "BOND_STATUS_UNBONDING"

--- a/integration_tests/test_staking.py
+++ b/integration_tests/test_staking.py
@@ -10,6 +10,7 @@ from .network import setup_custom_mantra
 from .utils import (
     DEFAULT_DENOM,
     DEFAULT_GAS_PRICE,
+    BondStatus,
     find_fee,
     find_log_event_attrs,
     wait_for_block,
@@ -136,7 +137,7 @@ def test_join_validator(mantra):
 
     val = cli.validator(val_addr)
     assert not val.get("jailed")
-    assert val["status"] == "BOND_STATUS_BONDED"
+    assert val["status"] == BondStatus.BONDED.value
     assert val["tokens"] == str(staked)
     assert val["description"]["moniker"] == moniker
     assert val["commission"]["commission_rates"] == {
@@ -166,7 +167,7 @@ def test_min_self_delegation(custom_mantra):
         cli.unbond_amount(val, f"{amt}{DEFAULT_DENOM}", _from=addr, gas=gas)["code"]
         == 0
     )
-    assert cli.validator(val).get("status") == "BOND_STATUS_BONDED"
+    assert cli.validator(val).get("status") == BondStatus.BONDED.value
     assert cli.unbond_amount(val, f"1{DEFAULT_DENOM}", _from=addr, gas=gas)["code"] == 0
     wait_for_new_blocks(cli, 2)
-    assert cli.validator(val).get("status") == "BOND_STATUS_UNBONDING"
+    assert cli.validator(val).get("status") == BondStatus.UNBONDING.value

--- a/integration_tests/test_staking_precompile.py
+++ b/integration_tests/test_staking_precompile.py
@@ -14,11 +14,18 @@ from .utils import (
 )
 
 DELEGATE = ContractFunction.from_abi("delegate(address,string,uint256)(bool)")
+DELEGATION = ContractFunction.from_abi(
+    "delegation(address,string)(uint256,(string,uint256))"
+)
 UNDELEGATE = ContractFunction.from_abi("undelegate(address,string,uint256)(int64)")
+REDELEGATE = ContractFunction.from_abi(
+    "redelegate(address,string,string,uint256)(int64)"
+)
 STAKING = to_checksum_address("0x0000000000000000000000000000000000000800")
 
+pytestmark = pytest.mark.asyncio
 
-@pytest.mark.asyncio
+
 async def test_staking_delegate(mantra):
     cli = mantra.cosmos_cli()
     name = "signer1"
@@ -38,7 +45,6 @@ async def test_staking_delegate(mantra):
     assert balance_bf == balance + amt * WEI_PER_UOM + fee
 
 
-@pytest.mark.asyncio
 async def test_staking_unbond(mantra):
     cli = mantra.cosmos_cli()
     name = "signer1"
@@ -78,3 +84,30 @@ async def test_staking_unbond(mantra):
     wait_for_block_time(cli, isoparse(data["completion_time"]) + timedelta(seconds=1))
     balance = await w3.eth.get_balance(acct.address)
     assert balance == balance_bf - (sum(amounts) - unbonded_amt) * WEI_PER_UOM - fee
+
+
+async def test_staking_redelegate(mantra):
+    cli = mantra.cosmos_cli()
+    name = "signer1"
+    acct = ACCOUNTS[name]
+    val_ops = [v["operator_address"] for v in cli.validators()[:2]]
+    w3 = mantra.async_w3
+    amounts = [3, 4]
+    fee = 0
+
+    for i, amt in enumerate(amounts):
+        res = await DELEGATE(acct.address, val_ops[i], amt).transact(
+            w3, acct.address, to=STAKING
+        )
+        assert res.status == 1
+        fee += res["gasUsed"] * res["effectiveGasPrice"]
+
+    _, balance_bf = await DELEGATION(acct.address, val_ops[0]).call(w3, to=STAKING)
+    redelegate_amt = 2
+    res = await REDELEGATE(
+        acct.address, val_ops[0], val_ops[1], redelegate_amt
+    ).transact(w3, acct.address, to=STAKING)
+    assert res.status == 1
+    fee += res["gasUsed"] * res["effectiveGasPrice"]
+    _, balance = await DELEGATION(acct.address, val_ops[0]).call(w3, to=STAKING)
+    assert balance_bf[1] == balance[1] + redelegate_amt

--- a/integration_tests/test_staking_precompile.py
+++ b/integration_tests/test_staking_precompile.py
@@ -1,0 +1,80 @@
+from datetime import timedelta
+
+import pytest
+import requests
+from dateutil.parser import isoparse
+from eth_contract.contract import ContractFunction
+from eth_utils import to_checksum_address
+
+from .utils import (
+    ACCOUNTS,
+    WEI_PER_UOM,
+    find_log_event_attrs,
+    wait_for_block_time,
+)
+
+DELEGATE = ContractFunction.from_abi("delegate(address,string,uint256)(bool)")
+UNDELEGATE = ContractFunction.from_abi("undelegate(address,string,uint256)(int64)")
+STAKING = to_checksum_address("0x0000000000000000000000000000000000000800")
+
+
+@pytest.mark.asyncio
+async def test_staking_delegate(mantra):
+    cli = mantra.cosmos_cli()
+    name = "signer1"
+    amt = 2
+    acct = ACCOUNTS[name]
+    bonded = cli.staking_pool()
+    w3 = mantra.async_w3
+    balance_bf = await w3.eth.get_balance(acct.address)
+    validator = cli.validators()[0]["operator_address"]
+    res = await DELEGATE(acct.address, validator, amt).transact(
+        w3, acct.address, to=STAKING
+    )
+    assert res.status == 1
+    fee = res["gasUsed"] * res["effectiveGasPrice"]
+    assert cli.staking_pool() == bonded + amt
+    balance = await w3.eth.get_balance(acct.address)
+    assert balance_bf == balance + amt * WEI_PER_UOM + fee
+
+
+@pytest.mark.asyncio
+async def test_staking_unbond(mantra):
+    cli = mantra.cosmos_cli()
+    name = "signer1"
+    acct = ACCOUNTS[name]
+    val_ops = [v["operator_address"] for v in cli.validators()[:2]]
+    w3 = mantra.async_w3
+    balance_bf = await w3.eth.get_balance(acct.address)
+    bonded_bf = cli.staking_pool()
+    amounts = [3, 4]
+    fee = 0
+
+    for i, amt in enumerate(amounts):
+        res = await DELEGATE(acct.address, val_ops[i], amt).transact(
+            w3, acct.address, to=STAKING
+        )
+        assert res.status == 1
+        fee += res["gasUsed"] * res["effectiveGasPrice"]
+
+    assert cli.staking_pool() == bonded_bf + sum(amounts)
+    balance = await w3.eth.get_balance(acct.address)
+    assert balance == balance_bf - sum(amounts) * WEI_PER_UOM - fee
+
+    unbonded_bf = cli.staking_pool(bonded=False)
+    unbonded_amt = 2
+    res = await UNDELEGATE(acct.address, val_ops[i], unbonded_amt).transact(
+        w3, acct.address, to=STAKING
+    )
+    assert res.status == 1
+    fee += res["gasUsed"] * res["effectiveGasPrice"]
+    assert cli.staking_pool(bonded=False) == unbonded_bf + unbonded_amt
+    blk = res["blockNumber"]
+    rsp = requests.get(f"{cli.node_rpc_http}/block_results?height={blk}").json()
+    rsp = next((tx for tx in rsp["result"]["txs_results"] if tx["code"] == 0), None)
+    data = find_log_event_attrs(
+        rsp["events"], "unbond", lambda attrs: "completion_time" in attrs
+    )
+    wait_for_block_time(cli, isoparse(data["completion_time"]) + timedelta(seconds=1))
+    balance = await w3.eth.get_balance(acct.address)
+    assert balance == balance_bf - (sum(amounts) - unbonded_amt) * WEI_PER_UOM - fee

--- a/integration_tests/test_staking_precompile.py
+++ b/integration_tests/test_staking_precompile.py
@@ -19,6 +19,7 @@ from .utils import (
     DEFAULT_DENOM,
     WEI_PER_ETH,
     WEI_PER_UOM,
+    BondStatus,
     find_log_event_attrs,
     wait_for_block,
     wait_for_block_time,
@@ -26,18 +27,9 @@ from .utils import (
 )
 
 DELEGATE = ContractFunction.from_abi("delegate(address,string,uint256)")
-DELEGATION = ContractFunction.from_abi(
-    "delegation(address,string)(uint256,(string,uint256))"
-)
 UNDELEGATE = ContractFunction.from_abi("undelegate(address,string,uint256)")
-REDELEGATE = ContractFunction.from_abi("redelegate(address,string,string,uint256)")
-CREATE_VALIDATOR = ContractFunction.from_abi(
-    "createValidator((string,string,string,string,string),(uint256,uint256,uint256),uint256,address,string,uint256)"  # noqa: E501
-)
-EDIT_VALIDATOR = ContractFunction.from_abi(
-    "editValidator((string,string,string,string,string),address,int256,int256)"
-)
 STAKING = to_checksum_address("0x0000000000000000000000000000000000000800")
+
 
 pytestmark = pytest.mark.asyncio
 
@@ -54,15 +46,26 @@ def custom_mantra(request, tmp_path_factory):
     )
 
 
+async def get_validators(w3):
+    VALIDATORS = ContractFunction.from_abi(
+        "validators(string,(bytes,uint64,uint64,bool,bool))((string,string,bool,uint8,uint256,uint256,string,int64,int64,uint256,uint256)[],(bytes,uint64))"  # noqa: E501
+    )
+    res, _ = await VALIDATORS(BondStatus.BONDED.value, [b"", 0, 10, False, False]).call(
+        w3, to=STAKING
+    )
+    return res
+
+
 async def test_staking_delegate(mantra):
     cli = mantra.cosmos_cli()
+    w3 = mantra.async_w3
     name = "signer1"
     amt = 2
     acct = ACCOUNTS[name]
     bonded = cli.staking_pool()
-    w3 = mantra.async_w3
     balance_bf = await w3.eth.get_balance(acct.address)
-    validator = cli.validators()[0]["operator_address"]
+    res = await get_validators(w3)
+    validator = cli.debug_addr(res[0][0], bech="val")
     res = await DELEGATE(acct.address, validator, amt).transact(
         w3, acct.address, to=STAKING
     )
@@ -75,10 +78,11 @@ async def test_staking_delegate(mantra):
 
 async def test_staking_unbond(mantra):
     cli = mantra.cosmos_cli()
+    w3 = mantra.async_w3
     name = "signer1"
     acct = ACCOUNTS[name]
-    val_ops = [v["operator_address"] for v in cli.validators()[:2]]
-    w3 = mantra.async_w3
+    res = await get_validators(w3)
+    val_ops = [cli.debug_addr(validator[0], bech="val") for validator in res[:2]]
     balance_bf = await w3.eth.get_balance(acct.address)
     bonded_bf = cli.staking_pool()
     amounts = [3, 4]
@@ -116,10 +120,11 @@ async def test_staking_unbond(mantra):
 
 async def test_staking_redelegate(mantra):
     cli = mantra.cosmos_cli()
+    w3 = mantra.async_w3
     name = "signer1"
     acct = ACCOUNTS[name]
-    val_ops = [v["operator_address"] for v in cli.validators()[:2]]
-    w3 = mantra.async_w3
+    res = await get_validators(w3)
+    val_ops = [cli.debug_addr(validator[0], bech="val") for validator in res[:2]]
     amounts = [3, 4]
     fee = 0
 
@@ -130,8 +135,12 @@ async def test_staking_redelegate(mantra):
         assert res.status == 1
         fee += res["gasUsed"] * res["effectiveGasPrice"]
 
+    DELEGATION = ContractFunction.from_abi(
+        "delegation(address,string)(uint256,(string,uint256))"
+    )
     _, balance_bf = await DELEGATION(acct.address, val_ops[0]).call(w3, to=STAKING)
     redelegate_amt = 2
+    REDELEGATE = ContractFunction.from_abi("redelegate(address,string,string,uint256)")
     res = await REDELEGATE(
         acct.address, val_ops[0], val_ops[1], redelegate_amt
     ).transact(w3, acct.address, to=STAKING)
@@ -195,6 +204,9 @@ async def test_join_validator(mantra):
         int(0.01 * WEI_PER_ETH),
     ]
     min_self_delegation = 1
+    CREATE_VALIDATOR = ContractFunction.from_abi(
+        "createValidator((string,string,string,string,string),(uint256,uint256,uint256),uint256,address,string,uint256)"  # noqa: E501
+    )
     res = await CREATE_VALIDATOR(
         desc, commission, min_self_delegation, acct.address, pubkey, staked
     ).transact(w3, acct, to=STAKING, gas=200_000)
@@ -205,7 +217,7 @@ async def test_join_validator(mantra):
 
     val = cli.validator(val_addr)
     assert not val.get("jailed")
-    assert val["status"] == "BOND_STATUS_BONDED"
+    assert val["status"] == BondStatus.BONDED.value
     assert val["tokens"] == str(staked)
     assert val["description"]["moniker"] == moniker
     assert val["commission"]["commission_rates"] == {
@@ -214,6 +226,9 @@ async def test_join_validator(mantra):
         "max_change_rate": "0.010000000000000000",
     }
 
+    EDIT_VALIDATOR = ContractFunction.from_abi(
+        "editValidator((string,string,string,string,string),address,int256,int256)"
+    )
     msg = "commission cannot be changed more than once in 24h"
     with pytest.raises(web3.exceptions.ContractLogicError, match=msg):
         await EDIT_VALIDATOR(
@@ -240,11 +255,11 @@ async def test_min_self_delegation(custom_mantra):
         w3, acct, to=STAKING, gas=gas
     )
     assert res.status == 1
-    assert cli.validator(val).get("status") == "BOND_STATUS_BONDED"
+    assert cli.validator(val).get("status") == BondStatus.BONDED.value
     amt = 1
     res = await UNDELEGATE(acct.address, val, amt).transact(
         w3, acct, to=STAKING, gas=gas
     )
     assert res.status == 1
     wait_for_new_blocks(cli, 2)
-    assert cli.validator(val).get("status") == "BOND_STATUS_UNBONDING"
+    assert cli.validator(val).get("status") == BondStatus.UNBONDING.value

--- a/integration_tests/test_staking_precompile.py
+++ b/integration_tests/test_staking_precompile.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import requests
+import web3
 from dateutil.parser import isoparse
 from eth_account import Account
 from eth_contract.contract import ContractFunction
@@ -15,7 +16,6 @@ from pystarport import cluster
 from .utils import (
     ACCOUNTS,
     DEFAULT_DENOM,
-    DEFAULT_GAS_PRICE,
     WEI_PER_ETH,
     WEI_PER_UOM,
     find_log_event_attrs,
@@ -23,16 +23,17 @@ from .utils import (
     wait_for_block_time,
 )
 
-DELEGATE = ContractFunction.from_abi("delegate(address,string,uint256)(bool)")
+DELEGATE = ContractFunction.from_abi("delegate(address,string,uint256)")
 DELEGATION = ContractFunction.from_abi(
     "delegation(address,string)(uint256,(string,uint256))"
 )
-UNDELEGATE = ContractFunction.from_abi("undelegate(address,string,uint256)(int64)")
-REDELEGATE = ContractFunction.from_abi(
-    "redelegate(address,string,string,uint256)(int64)"
-)
+UNDELEGATE = ContractFunction.from_abi("undelegate(address,string,uint256)")
+REDELEGATE = ContractFunction.from_abi("redelegate(address,string,string,uint256)")
 CREATE_VALIDATOR = ContractFunction.from_abi(
-    "createValidator((string,string,string,string,string),(uint256,uint256,uint256),uint256,address,string,uint256)(bool)"  # noqa: E501
+    "createValidator((string,string,string,string,string),(uint256,uint256,uint256),uint256,address,string,uint256)"  # noqa: E501
+)
+EDIT_VALIDATOR = ContractFunction.from_abi(
+    "editValidator((string,string,string,string,string),address,int256,int256)"
 )
 STAKING = to_checksum_address("0x0000000000000000000000000000000000000800")
 
@@ -163,8 +164,6 @@ async def test_join_validator(mantra):
     wait_for_block(cli, cli.block_height())
 
     count = len(cli.validators())
-    gas = 420_000
-
     pubkey = (
         cli.raw(
             "comet",
@@ -175,7 +174,6 @@ async def test_join_validator(mantra):
         .decode()
     )
     pubkey = json.loads(pubkey)["key"]
-    print("mm-pubkey", pubkey)
     desc = [moniker, "identity", "website", "securityContact", "details"]
     commission = [
         int(0.1 * WEI_PER_ETH),
@@ -185,10 +183,9 @@ async def test_join_validator(mantra):
     min_self_delegation = 1
     res = await CREATE_VALIDATOR(
         desc, commission, min_self_delegation, validator.address, pubkey, staked
-    ).transact(w3, validator, to=STAKING)
+    ).transact(w3, validator, to=STAKING, gas=200_000)
     assert res.status == 1
 
-    opts = {"gas_prices": DEFAULT_GAS_PRICE, "gas": gas}
     time.sleep(2)
     assert len(cli.validators()) == count + 1
 
@@ -202,13 +199,16 @@ async def test_join_validator(mantra):
         "max_rate": "0.200000000000000000",
         "max_change_rate": "0.010000000000000000",
     }
-    rsp = cli.edit_validator(commission_rate="0.2", **opts)
-    if rsp.get("code") == 0:
-        rsp = cli.event_query_tx_for(rsp["txhash"])
-    assert rsp["code"] == 12
-    assert "commission cannot be changed more than once in 24h" in rsp["raw_log"]
-    rsp = cli.edit_validator(new_moniker="awesome node", **opts)
-    if rsp.get("code") == 0:
-        rsp = cli.event_query_tx_for(rsp["txhash"])
-    assert rsp["code"] == 0
+
+    msg = "commission cannot be changed more than once in 24h"
+    with pytest.raises(web3.exceptions.ContractLogicError, match=msg):
+        await EDIT_VALIDATOR(
+            desc, validator.address, commission[0] * 2, min_self_delegation
+        ).transact(w3, validator, to=STAKING)
+
+    desc[0] = "awesome node"
+    res = await EDIT_VALIDATOR(desc, validator.address, -1, -1).transact(
+        w3, validator, to=STAKING
+    )
+    assert res.status == 1
     assert cli.validator(val_addr)["description"]["moniker"] == "awesome node"

--- a/integration_tests/test_staking_precompile.py
+++ b/integration_tests/test_staking_precompile.py
@@ -13,6 +13,7 @@ from eth_contract.contract import ContractFunction
 from eth_utils import to_checksum_address
 from pystarport import cluster
 
+from .network import setup_custom_mantra
 from .utils import (
     ACCOUNTS,
     DEFAULT_DENOM,
@@ -21,6 +22,7 @@ from .utils import (
     find_log_event_attrs,
     wait_for_block,
     wait_for_block_time,
+    wait_for_new_blocks,
 )
 
 DELEGATE = ContractFunction.from_abi("delegate(address,string,uint256)")
@@ -38,6 +40,18 @@ EDIT_VALIDATOR = ContractFunction.from_abi(
 STAKING = to_checksum_address("0x0000000000000000000000000000000000000800")
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(scope="module")
+def custom_mantra(request, tmp_path_factory):
+    chain = request.config.getoption("chain_config")
+    path = tmp_path_factory.mktemp("staking")
+    yield from setup_custom_mantra(
+        path,
+        27200,
+        Path(__file__).parent / "configs/staking.jsonnet",
+        chain=chain,
+    )
 
 
 async def test_staking_delegate(mantra):
@@ -131,7 +145,7 @@ async def test_join_validator(mantra):
     w3 = mantra.async_w3
     cli = mantra.cosmos_cli()
     mnemonic = os.getenv("VALIDATOR4_MNEMONIC")
-    validator = Account.from_mnemonic(mnemonic)
+    acct = Account.from_mnemonic(mnemonic)
     data = Path(mantra.base_dir).parent
     chain_id = mantra.config["chain_id"]
     clustercli = cluster.ClusterCLI(data, cmd="mantrachaind", chain_id=chain_id)
@@ -182,8 +196,8 @@ async def test_join_validator(mantra):
     ]
     min_self_delegation = 1
     res = await CREATE_VALIDATOR(
-        desc, commission, min_self_delegation, validator.address, pubkey, staked
-    ).transact(w3, validator, to=STAKING, gas=200_000)
+        desc, commission, min_self_delegation, acct.address, pubkey, staked
+    ).transact(w3, acct, to=STAKING, gas=200_000)
     assert res.status == 1
 
     time.sleep(2)
@@ -203,12 +217,34 @@ async def test_join_validator(mantra):
     msg = "commission cannot be changed more than once in 24h"
     with pytest.raises(web3.exceptions.ContractLogicError, match=msg):
         await EDIT_VALIDATOR(
-            desc, validator.address, commission[0] * 2, min_self_delegation
-        ).transact(w3, validator, to=STAKING)
+            desc, acct.address, commission[0] * 2, min_self_delegation
+        ).transact(w3, acct, to=STAKING)
 
     desc[0] = "awesome node"
-    res = await EDIT_VALIDATOR(desc, validator.address, -1, -1).transact(
-        w3, validator, to=STAKING
+    res = await EDIT_VALIDATOR(desc, acct.address, -1, -1).transact(
+        w3, acct, to=STAKING
     )
     assert res.status == 1
     assert cli.validator(val_addr)["description"]["moniker"] == "awesome node"
+
+
+async def test_min_self_delegation(custom_mantra):
+    mnemonic = os.getenv("VALIDATOR4_MNEMONIC")
+    acct = Account.from_mnemonic(mnemonic)
+    cli = custom_mantra.cosmos_cli(i=3)
+    w3 = custom_mantra.async_w3
+    val = cli.address("validator", bech="val")
+    amt = 9_000_000_000_000_000_000
+    gas = 400_000
+    res = await UNDELEGATE(acct.address, val, amt).transact(
+        w3, acct, to=STAKING, gas=gas
+    )
+    assert res.status == 1
+    assert cli.validator(val).get("status") == "BOND_STATUS_BONDED"
+    amt = 1
+    res = await UNDELEGATE(acct.address, val, amt).transact(
+        w3, acct, to=STAKING, gas=gas
+    )
+    assert res.status == 1
+    wait_for_new_blocks(cli, 2)
+    assert cli.validator(val).get("status") == "BOND_STATUS_UNBONDING"

--- a/integration_tests/test_staking_precompile.py
+++ b/integration_tests/test_staking_precompile.py
@@ -1,15 +1,25 @@
+import json
+import os
+import time
 from datetime import timedelta
+from pathlib import Path
 
 import pytest
 import requests
 from dateutil.parser import isoparse
+from eth_account import Account
 from eth_contract.contract import ContractFunction
 from eth_utils import to_checksum_address
+from pystarport import cluster
 
 from .utils import (
     ACCOUNTS,
+    DEFAULT_DENOM,
+    DEFAULT_GAS_PRICE,
+    WEI_PER_ETH,
     WEI_PER_UOM,
     find_log_event_attrs,
+    wait_for_block,
     wait_for_block_time,
 )
 
@@ -20,6 +30,9 @@ DELEGATION = ContractFunction.from_abi(
 UNDELEGATE = ContractFunction.from_abi("undelegate(address,string,uint256)(int64)")
 REDELEGATE = ContractFunction.from_abi(
     "redelegate(address,string,string,uint256)(int64)"
+)
+CREATE_VALIDATOR = ContractFunction.from_abi(
+    "createValidator((string,string,string,string,string),(uint256,uint256,uint256),uint256,address,string,uint256)(bool)"  # noqa: E501
 )
 STAKING = to_checksum_address("0x0000000000000000000000000000000000000800")
 
@@ -111,3 +124,91 @@ async def test_staking_redelegate(mantra):
     fee += res["gasUsed"] * res["effectiveGasPrice"]
     _, balance = await DELEGATION(acct.address, val_ops[0]).call(w3, to=STAKING)
     assert balance_bf[1] == balance[1] + redelegate_amt
+
+
+async def test_join_validator(mantra):
+    w3 = mantra.async_w3
+    cli = mantra.cosmos_cli()
+    mnemonic = os.getenv("VALIDATOR4_MNEMONIC")
+    validator = Account.from_mnemonic(mnemonic)
+    data = Path(mantra.base_dir).parent
+    chain_id = mantra.config["chain_id"]
+    clustercli = cluster.ClusterCLI(data, cmd="mantrachaind", chain_id=chain_id)
+    moniker = "new joined"
+    node_index = clustercli.create_node(moniker=moniker, mnemonic=mnemonic)
+    cli = clustercli.cosmos_cli(node_index)
+    cli0 = mantra.cosmos_cli()
+    staked = 10_000_000_000_000_000_000
+    fund = f"{staked + 1_000_000}{DEFAULT_DENOM}"
+    val_addr = cli.address("validator", bech="val")
+    addr = cli.address("validator")
+
+    res = cli0.transfer(cli0.address("community"), addr, fund)
+    assert res["code"] == 0, res
+    # Modify the json-rpc addresses to avoid conflict
+    cluster.edit_app_cfg(
+        clustercli.home(node_index) / "config/app.toml",
+        clustercli.base_port(node_index),
+        {
+            "json-rpc": {
+                "enable": True,
+                "address": "127.0.0.1:{EVMRPC_PORT}",
+                "ws-address": "127.0.0.1:{EVMRPC_PORT_WS}",
+            }
+        },
+    )
+    clustercli.supervisor.startProcess(f"{chain_id}-node{node_index}")
+    wait_for_block(cli, cli0.block_height() + 1)
+    time.sleep(1)
+    wait_for_block(cli, cli.block_height())
+
+    count = len(cli.validators())
+    gas = 420_000
+
+    pubkey = (
+        cli.raw(
+            "comet",
+            "show-validator",
+            home=cli.data_dir,
+        )
+        .strip()
+        .decode()
+    )
+    pubkey = json.loads(pubkey)["key"]
+    print("mm-pubkey", pubkey)
+    desc = [moniker, "identity", "website", "securityContact", "details"]
+    commission = [
+        int(0.1 * WEI_PER_ETH),
+        int(0.2 * WEI_PER_ETH),
+        int(0.01 * WEI_PER_ETH),
+    ]
+    min_self_delegation = 1
+    res = await CREATE_VALIDATOR(
+        desc, commission, min_self_delegation, validator.address, pubkey, staked
+    ).transact(w3, validator, to=STAKING)
+    assert res.status == 1
+
+    opts = {"gas_prices": DEFAULT_GAS_PRICE, "gas": gas}
+    time.sleep(2)
+    assert len(cli.validators()) == count + 1
+
+    val = cli.validator(val_addr)
+    assert not val.get("jailed")
+    assert val["status"] == "BOND_STATUS_BONDED"
+    assert val["tokens"] == str(staked)
+    assert val["description"]["moniker"] == moniker
+    assert val["commission"]["commission_rates"] == {
+        "rate": "0.100000000000000000",
+        "max_rate": "0.200000000000000000",
+        "max_change_rate": "0.010000000000000000",
+    }
+    rsp = cli.edit_validator(commission_rate="0.2", **opts)
+    if rsp.get("code") == 0:
+        rsp = cli.event_query_tx_for(rsp["txhash"])
+    assert rsp["code"] == 12
+    assert "commission cannot be changed more than once in 24h" in rsp["raw_log"]
+    rsp = cli.edit_validator(new_moniker="awesome node", **opts)
+    if rsp.get("code") == 0:
+        rsp = cli.event_query_tx_for(rsp["txhash"])
+    assert rsp["code"] == 0
+    assert cli.validator(val_addr)["description"]["moniker"] == "awesome node"

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -13,6 +13,7 @@ import sys
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from enum import Enum
 from itertools import takewhile
 from pathlib import Path
 from urllib.parse import urlparse
@@ -75,6 +76,13 @@ WETH_ADDRESS = create2_address(get_initcode(WETH9_ARTIFACT), WETH_SALT)
 MockERC20_ARTIFACT = json.loads(
     Path(__file__).parent.joinpath("contracts/contracts/MockERC20.json").read_text()
 )
+
+
+class BondStatus(Enum):
+    UNSPECIFIED = "BOND_STATUS_UNSPECIFIED"
+    UNBONDED = "BOND_STATUS_UNBONDED"
+    UNBONDING = "BOND_STATUS_UNBONDING"
+    BONDED = "BOND_STATUS_BONDED"
 
 
 class Contract:

--- a/nix/mantrachain/default.nix
+++ b/nix/mantrachain/default.nix
@@ -84,10 +84,10 @@ buildGo123Module' rec {
   src = fetchFromGitHub {
     owner = "MANTRA-Chain";
     repo = pname;
-    rev = "6619d7c8a80831b51746145e67b4b90ea60350eb";
-    hash = "sha256-iX8SRRXj50+jrdExhQHwHVyNlI4l/UT6613VvBp+B8A=";
+    rev = "176618c174bcee81fb596be2a78ce507ee4cef2f";
+    hash = "sha256-z/FhVZZZzNAQD+y+CIQ4Ru4jxsPeb4969yfR3HMdJ8M=";
   };
-  vendorHash = "sha256-BOYJVYrS9PjgD7MQ+fL9GjDh3b4212RkBHC/12POE10=";
+  vendorHash = "sha256-e3cQdKFYkepL8UG2a7vGpUq+T+SFUbFIePRL5oCAJeQ=";
   proxyVendor = true;
   subPackages = [ "cmd/mantrachaind" ];
   CGO_ENABLED = "1";

--- a/scripts/env.template
+++ b/scripts/env.template
@@ -1,6 +1,7 @@
 export VALIDATOR1_MNEMONIC="visit craft resemble online window solution west chuckle music diesel vital settle comic tribe project blame bulb armed flower region sausage mercy arrive release"
 export VALIDATOR2_MNEMONIC="direct travel shrug hand twice agent sail sell jump phone velvet pilot mango charge usual multiply orient garment bleak virtual action mention panda vast"
 export VALIDATOR3_MNEMONIC="panda much deny whale fun iron liquid rookie rice ridge artist slush legend salad adapt public all thunder galaxy give ostrich endless prosper good"
+export VALIDATOR4_MNEMONIC="echo embody public spot theory explain paddle layer bless finish method bread journey race couch deer image movie element rival clarify dice loan file"
 export COMMUNITY_MNEMONIC="notable error gospel wave pair ugly measure elite toddler cost various fly make eye ketchup despair slab throw tribe swarm word fruit into inmate"
 export SIGNER1_MNEMONIC="shed crumble dismiss loyal latin million oblige gesture shrug still oxygen custom remove ribbon disorder palace addict again blanket sad flock consider obey popular"
 export SIGNER2_MNEMONIC="night renew tonight dinner shaft scheme domain oppose echo summer broccoli agent face guitar surface belt veteran siren poem alcohol menu custom crunch index"


### PR DESCRIPTION
Closes https://github.com/MANTRA-Chain/mantrachain-e2e/issues/87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled staking EVM precompile (exposed at 0x000...0800).
  - Expanded CLI tooling with staking operations: delegate, unbond, redelegate, create validator, and related queries.
  - Added configurable unbonding time in genesis configurations.
  - Introduced support for an additional validator via environment variable.

- Tests
  - Added comprehensive integration tests covering staking flows, precompile interactions, validator onboarding, and minimum self-delegation behavior.

- Chores
  - Updated eth-contract dependency source/branch.
  - Bumped Mantrachain Nix source revision and vendor hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->