### PR TITLE
Problem: test-env not in default flake env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,15 +28,15 @@
       rec {
         legacyPackages = pkgs;
         packages.default = pkgs.mantrachain;
-        devShells = rec {
+        devShells = {
           default = pkgs.mkShell {
             buildInputs = [
               packages.default.go
               pkgs.nixfmt-rfc-style
               pkgs.solc
+              pkgs.test-env
             ];
           };
-          full = pkgs.mkShell { buildInputs = default.buildInputs ++ [ pkgs.test-env ]; };
         };
       }
     ))


### PR DESCRIPTION
Solution:
- we should have test-env as default since it's dedicated e2e repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified development environment configuration by consolidating shell variants to a single default entry.
  * Updated the default development environment to include testing tools for enhanced development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->