### PR TITLE
Problem: go 1.25 is not supported in nix build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,9 +26,9 @@ jobs:
             **/poetry.lock
             **/pyproject.toml
             **/*.py
-      - uses: cachix/install-nix-action@6a9a9e84a173d90b3ffb42c5ddaf9ea033fad011 # v23
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
-          nix_path: nixpkgs=channel:nixos-22.11
+          nix_path: nixpkgs=channel:nixos-24.11
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/tests-e2e-nix-connect.yml
+++ b/.github/workflows/tests-e2e-nix-connect.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 1
-      - uses: cachix/install-nix-action@6a9a9e84a173d90b3ffb42c5ddaf9ea033fad011 # v23
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
-          nix_path: nixpkgs=channel:nixos-25.05
+          nix_path: nixpkgs=channel:nixos-24.11
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.NIX_GH_TOKEN }}
       - uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12

--- a/.github/workflows/tests-e2e-nix.yml
+++ b/.github/workflows/tests-e2e-nix.yml
@@ -38,7 +38,7 @@ jobs:
             docs
             *.md
             **/*.md
-      - uses: cachix/install-nix-action@6a9a9e84a173d90b3ffb42c5ddaf9ea033fad011 # v23
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
           nix_path: nixpkgs=channel:nixos-24.11
           extra_nix_config: |
@@ -96,9 +96,9 @@ jobs:
             docs
             *.md
             **/*.md
-      - uses: cachix/install-nix-action@56a7bb7b56d9a92d4fd1bc05758de7eea4a370a8 # v31.6.0
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
-          nix_path: nixpkgs=channel:nixos-22.11
+          nix_path: nixpkgs=channel:nixos-24.11
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
         if: steps.changed-files.outputs.only_changed == 'false'

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -26,7 +26,10 @@ import sources.nixpkgs {
     (_: pkgs: { test-env = pkgs.callPackage ./testenv.nix { }; })
     (_: pkgs: { cosmovisor = pkgs.callPackage ./cosmovisor.nix { }; })
     (_: pkgs: { mantrachaind = pkgs.callPackage ./mantrachain/default.nix { }; })
-    (_: pkgs: { evmd = pkgs.callPackage ./evm/default.nix { }; })
+    (_: pkgs: { 
+      go_1_25 = pkgs.callPackage ./go_1_25.nix { };
+      evmd = pkgs.callPackage ./evm/default.nix { }; 
+    })
   ];
   config = { };
   inherit system;

--- a/nix/evm/default.nix
+++ b/nix/evm/default.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  buildGo123Module,
+  buildGoModule,
+  go_1_25,
   fetchFromGitHub,
   rev ? "dirty",
   nativeByteOrder ? true, # nativeByteOrder mode will panic on big endian machines
@@ -13,9 +14,9 @@ let
   pname = "evmd";
 
   # Use static packages for Linux to ensure musl compatibility
-  buildPackages = if stdenv.isLinux then pkgsStatic else { inherit stdenv buildGo123Module; };
+  buildPackages = if stdenv.isLinux then pkgsStatic else { inherit stdenv; buildGoModule = buildGoModule.override { go = go_1_25; }; };
   buildStdenv = buildPackages.stdenv;
-  buildGo123Module' = if stdenv.isLinux then buildPackages.buildGo123Module else buildGo123Module;
+  buildGoModule' = if stdenv.isLinux then buildPackages.buildGoModule else (buildGoModule.override { go = go_1_25; });
 
   tags =
     [
@@ -46,7 +47,7 @@ let
     ];
 
 in
-buildGo123Module' rec {
+  buildGoModule' rec {
   inherit
     pname
     version
@@ -55,21 +56,22 @@ buildGo123Module' rec {
     ;
   stdenv = buildStdenv;
   src = fetchFromGitHub {
-    owner = "MANTRA-Chain";
+    owner = "cosmos";
     repo = "evm";
-    rev = "d8f4ae9d33a6dd51a5698eecb97c21050239d688";
-    hash = "sha256-lhepP1SCK9gE21FL2XqpOuQnmR3axpC6aI3IRrCrqzg=";
+    rev = "f6d50b4dfb19bacc4796fd7e1176cf37d41171f1";
+    hash = "sha256-e6LC7TD9/2m6dt2pyWz2JZQsYJKFverQsleU+3xlvPA=";
   };
   
-  vendorHash = "sha256-IDJHj2e2LBMe0BtwduG7/wLM/C2rRQyIUpbMawJAilk=";
+  vendorHash = "sha256-2IBRbZ6smfRcF8OMmXWEBBXZnvyt3e+3Z3UprSt8ACA=";
   proxyVendor = true;
   sourceRoot = "source/evmd";
   subPackages = [ "cmd/evmd" ];
-  CGO_ENABLED = "1";
+  env.CGO_ENABLED = "1";
 
   preBuild = ''
     mkdir -p $TMPDIR/lib
     export CGO_LDFLAGS="-L$TMPDIR/lib $CGO_LDFLAGS"
+    export GOTOOLCHAIN=local
   '';
 
   doCheck = false;

--- a/nix/evm/default.nix
+++ b/nix/evm/default.nix
@@ -66,10 +66,10 @@ in
   proxyVendor = true;
   sourceRoot = "source/evmd";
   subPackages = [ "cmd/evmd" ];
-  env.CGO_ENABLED = "1";
 
   preBuild = ''
     mkdir -p $TMPDIR/lib
+    export CGO_ENABLED=1
     export CGO_LDFLAGS="-L$TMPDIR/lib $CGO_LDFLAGS"
     export GOTOOLCHAIN=local
   '';

--- a/nix/evm/default.nix
+++ b/nix/evm/default.nix
@@ -16,7 +16,9 @@ let
   # Use static packages for Linux to ensure musl compatibility
   buildPackages = if stdenv.isLinux then pkgsStatic else { inherit stdenv; buildGoModule = buildGoModule.override { go = go_1_25; }; };
   buildStdenv = buildPackages.stdenv;
-  buildGoModule' = if stdenv.isLinux then buildPackages.buildGoModule else (buildGoModule.override { go = go_1_25; });
+  buildGoModule' = if stdenv.isLinux 
+    then (buildPackages.buildGoModule.override { go = go_1_25; })
+    else (buildGoModule.override { go = go_1_25; });
 
   tags =
     [

--- a/nix/evm/default.nix
+++ b/nix/evm/default.nix
@@ -58,11 +58,11 @@ in
   src = fetchFromGitHub {
     owner = "cosmos";
     repo = "evm";
-    rev = "f6d50b4dfb19bacc4796fd7e1176cf37d41171f1";
-    hash = "sha256-e6LC7TD9/2m6dt2pyWz2JZQsYJKFverQsleU+3xlvPA=";
+    rev = "79bcc14fefa4b5c82386a3fb0724c3f9a7688ba5";
+    hash = "sha256-QoQR7VBkAUMTj9M4qbAK76avjgiyH8htUeFFggVDExA=";
   };
   
-  vendorHash = "sha256-2IBRbZ6smfRcF8OMmXWEBBXZnvyt3e+3Z3UprSt8ACA=";
+  vendorHash = "sha256-DO9SS1c5p9hSMR2M+bCxci/kdjpN7a9TZhMZhq2Efag=";
   proxyVendor = true;
   sourceRoot = "source/evmd";
   subPackages = [ "cmd/evmd" ];

--- a/nix/go_1_25.nix
+++ b/nix/go_1_25.nix
@@ -1,0 +1,14 @@
+{ pkgs }:
+
+let
+  nixpkgs-unstable = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/7241bcbb4f099a66aafca120d37c65e8dda32717.tar.gz";
+    sha256 = "1awaf4s01snazyvy7s788m47dzc7k4vd8hj1ikxfvrrgpa1w03k2";
+  };
+  
+  unstable = import nixpkgs-unstable {
+    system = pkgs.system;
+    config = {};
+  };
+in
+  unstable.go_1_25 or pkgs.go_1_23

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "daa477e013dd736c939fcc111dc4dd889bc17c94",
-        "sha256": "1vbbl1iy5wxmwww8hi1ngcby6mnyzn7l5x9yxf58yd9z0nmx6p74",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "sha256": "1s2gr5rcyqvpr58vxdcb095mdhblij9bfzaximrva2243aal3dgx",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/daa477e013dd736c939fcc111dc4dd889bc17c94.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50ab793786d9de88ee30ec4e4c24fb4236fc2674.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
Closes https://github.com/MANTRA-Chain/mantrachain-e2e/issues/110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Go 1.25 toolchain support

* **Chores**
  * Updated CI workflows to use newer Nix installer versions and NixOS 24.11
  * Updated build dependencies and nixpkgs references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->