### PR TITLE
Problem: generic diamond cut utility not used

### DIFF
--- a/integration_tests/contracts/contracts/Greeter.sol
+++ b/integration_tests/contracts/contracts/Greeter.sol
@@ -23,4 +23,21 @@ contract Greeter {
     function intValue() public view returns (uint) {
         return n;
     }
+
+    function toRemove() pure public returns (string memory) {
+        return "toRemove";
+    }
+}
+
+contract GreeterV2 {
+    // replace
+    function greet() public pure returns (string memory) {
+        return "hello from v2";
+    }
+
+    // add
+    function newMethod() public pure returns (string memory) {
+        return "newMethod";
+    }
+
 }

--- a/integration_tests/diamond.py
+++ b/integration_tests/diamond.py
@@ -1,3 +1,7 @@
+"""
+https://eips.ethereum.org/EIPS/eip-2535
+"""
+
 from enum import IntEnum
 from typing import NamedTuple
 

--- a/integration_tests/diamond.py
+++ b/integration_tests/diamond.py
@@ -53,22 +53,20 @@ async def build_diamond_cut(
     old: str | None = None
 
     for sel in facet.function_selectors:
-        exiting = await IDiamondLoupe.fns.facetAddress(sel).call(w3, to=diamond)
-        if exiting == ZERO_ADDRESS:
+        existing = await IDiamondLoupe.fns.facetAddress(sel).call(w3, to=diamond)
+        if existing == ZERO_ADDRESS:
             add.append(sel)
-        elif exiting != facet.facet_address.lower():
+        elif existing.lower() != facet.facet_address.lower():
             replace.append(sel)
-            old = exiting
+            old = existing
 
     if old is not None:
         old_selectors = await IDiamondLoupe.fns.facetFunctionSelectors(old).call(
             w3, to=diamond
         )
+        new_selectors = set(facet.function_selectors)
         for old_sel in old_selectors:
-            for new_sel in facet.function_selectors:
-                if old_sel == new_sel:
-                    break
-            else:
+            if old_sel not in new_selectors:
                 remove.append(old_sel)
 
     cuts = []

--- a/integration_tests/diamond.py
+++ b/integration_tests/diamond.py
@@ -1,0 +1,109 @@
+from enum import IntEnum
+from typing import NamedTuple
+
+from eth_account.signers.base import BaseAccount
+from eth_contract.contract import Contract
+from eth_typing import ChecksumAddress
+from web3 import AsyncWeb3
+from web3.types import TxReceipt
+
+from .utils import ZERO_ADDRESS
+
+IDiamondCut = Contract.from_abi(
+    [
+        "struct FacetCut { address facetAddress; uint8 action; "
+        "bytes4[] functionSelectors; }",
+        "function diamondCut(FacetCut[] _diamondCut, address _init, bytes _calldata)",
+    ]
+)
+IDiamondLoupe = Contract.from_abi(
+    [
+        "struct Facet { address facetAddress; bytes4[] functionSelectors; }",
+        "function facets() returns (Facet[] facets_)",
+        "function facetFunctionSelectors(address _facet) returns "
+        "(bytes4[] memory facetFunctionSelectors_)",
+        "function facetAddresses() returns (address[] facetAddresses_)",
+        "function facetAddress(bytes4 _functionSelector) returns "
+        "(address facetAddress_)",
+    ]
+)
+
+
+class FacetCutAction(IntEnum):
+    ADD, REPLACE, REMOVE = range(3)
+
+
+class FacetCut(NamedTuple):
+    facet_address: str
+    action: FacetCutAction
+    function_selectors: list[bytes]
+
+
+class Facet(NamedTuple):
+    facet_address: str
+    function_selectors: list[bytes]
+
+
+async def build_diamond_cut(
+    w3: AsyncWeb3, diamond: ChecksumAddress, facet: Facet
+) -> list[FacetCut]:
+    add = []
+    replace = []
+    remove = []
+    old: str | None = None
+
+    for sel in facet.function_selectors:
+        exiting = await IDiamondLoupe.fns.facetAddress(sel).call(w3, to=diamond)
+        if exiting == ZERO_ADDRESS:
+            add.append(sel)
+        elif exiting != facet.facet_address.lower():
+            replace.append(sel)
+            old = exiting
+
+    if old is not None:
+        old_selectors = await IDiamondLoupe.fns.facetFunctionSelectors(old).call(
+            w3, to=diamond
+        )
+        for old_sel in old_selectors:
+            for new_sel in facet.function_selectors:
+                if old_sel == new_sel:
+                    break
+            else:
+                remove.append(old_sel)
+
+    cuts = []
+    if replace:
+        cuts.append(
+            FacetCut(
+                facet_address=facet.facet_address,
+                action=FacetCutAction.REPLACE,
+                function_selectors=replace,
+            )
+        )
+    if remove:
+        cuts.append(
+            FacetCut(
+                facet_address=ZERO_ADDRESS,
+                action=FacetCutAction.REMOVE,
+                function_selectors=remove,
+            )
+        )
+    if add:
+        cuts.append(
+            FacetCut(
+                facet_address=facet.facet_address,
+                action=FacetCutAction.ADD,
+                function_selectors=add,
+            )
+        )
+
+    return cuts
+
+
+async def cut_diamond(
+    w3: AsyncWeb3, deployer: BaseAccount, diamond: ChecksumAddress, facet: Facet
+) -> TxReceipt:
+    cuts = await build_diamond_cut(w3, diamond, facet)
+    return await IDiamondCut.fns.diamondCut(cuts, ZERO_ADDRESS, b"").transact(
+        w3, deployer, to=diamond
+    )

--- a/integration_tests/test_diamond.py
+++ b/integration_tests/test_diamond.py
@@ -2,35 +2,18 @@
 https://eips.ethereum.org/EIPS/eip-2535
 """
 
-from enum import IntEnum
-from typing import NamedTuple
-
 import pytest
+import web3
 from eth_contract.contract import Contract
 from eth_contract.deploy_utils import (
     ensure_create2_deployed,
     ensure_deployed_by_create2,
 )
-from eth_contract.utils import ZERO_ADDRESS, get_initcode, send_transaction
+from eth_contract.utils import get_initcode, send_transaction
 from web3 import AsyncWeb3
 
+from .diamond import Facet, FacetCut, FacetCutAction, cut_diamond
 from .utils import ACCOUNTS, build_contract_solcx, selectors
-
-
-class FacetCutAction(IntEnum):
-    ADD, REPLACE, REMOVE = range(3)
-
-
-class FacetCut(NamedTuple):
-    facet_address: str
-    action: FacetCutAction
-    function_selectors: list[bytes]
-
-
-class Facet(NamedTuple):
-    facet_address: str
-    function_selectors: list[bytes]
-
 
 DIAMOND_ARTIFACT = build_contract_solcx("Diamond")
 GREETER_ARTIFACT = build_contract_solcx("Greeter")
@@ -38,40 +21,17 @@ GREETER_ARTIFACT = build_contract_solcx("Greeter")
 IDiamondCut = Contract(DIAMOND_ARTIFACT["IDiamondCut"]["abi"])
 IDiamondLoupe = Contract(DIAMOND_ARTIFACT["IDiamondLoupe"]["abi"])
 IERC173 = Contract(DIAMOND_ARTIFACT["IERC173"]["abi"])
-IGreeter = Contract(GREETER_ARTIFACT["Greeter"]["abi"])
+IGreeter1 = Contract(GREETER_ARTIFACT["Greeter"]["abi"])
+IGreeter2 = Contract(GREETER_ARTIFACT["GreeterV2"]["abi"])
 
 DIAMOND_CUT_SELECTORS = selectors(DIAMOND_ARTIFACT["IDiamondCut"])
 DIAMOND_LOUPE_SELECTORS = selectors(DIAMOND_ARTIFACT["IDiamondLoupe"])
 OWNERSHIP_SELECTORS = selectors(DIAMOND_ARTIFACT["IERC173"])
-GREETER_SELECTORS = selectors(GREETER_ARTIFACT["Greeter"])
+GREETER1_SELECTORS = selectors(GREETER_ARTIFACT["Greeter"])
+GREETER2_SELECTORS = selectors(GREETER_ARTIFACT["GreeterV2"])
 
 
-async def deploy_greeter(w3: AsyncWeb3, deployer):
-    await ensure_create2_deployed(w3, deployer)
-    return await ensure_deployed_by_create2(
-        w3, deployer, get_initcode(GREETER_ARTIFACT["Greeter"])
-    )
-
-
-async def verify_facet_address(
-    w3: AsyncWeb3, diamond_address: str, selector: bytes, expected_address: str
-):
-    facet_addr = await IDiamondLoupe.fns.facetAddress(selector).call(
-        w3, to=diamond_address
-    )
-    assert facet_addr.lower() == expected_address.lower()
-
-
-async def set_and_verify_greeting(
-    w3: AsyncWeb3, deployer, diamond_address, message: str
-):
-    await IGreeter.fns.setGreeting(message).transact(w3, deployer, to=diamond_address)
-    result = await IGreeter.fns.greet().call(w3, to=diamond_address)
-    assert result == message
-    return result
-
-
-async def deploy_diamond(w3: AsyncWeb3, deployer, extra_facets=None):
+async def deploy_diamond(w3: AsyncWeb3, deployer):
     await ensure_create2_deployed(w3, deployer)
     cut_address = await ensure_deployed_by_create2(
         w3, deployer, get_initcode(DIAMOND_ARTIFACT["DiamondCutFacet"])
@@ -79,120 +39,68 @@ async def deploy_diamond(w3: AsyncWeb3, deployer, extra_facets=None):
     loupe_address = await ensure_deployed_by_create2(
         w3, deployer, get_initcode(DIAMOND_ARTIFACT["DiamondLoupeFacet"])
     )
-    ownership_address = await ensure_deployed_by_create2(
-        w3, deployer, get_initcode(DIAMOND_ARTIFACT["OwnershipFacet"])
-    )
     cut_cut = FacetCut(cut_address, FacetCutAction.ADD, DIAMOND_CUT_SELECTORS)
     loupe_cut = FacetCut(loupe_address, FacetCutAction.ADD, DIAMOND_LOUPE_SELECTORS)
-    ownership_cut = FacetCut(ownership_address, FacetCutAction.ADD, OWNERSHIP_SELECTORS)
 
-    # register the very core facet in constructor
-    facets_in_constructor = [cut_cut]
-    if extra_facets:
-        facets_in_constructor.extend(extra_facets)
-
+    # always deploy a new contract
     receipt = await send_transaction(
         w3,
         deployer,
         data=get_initcode(
-            DIAMOND_ARTIFACT["Diamond"], facets_in_constructor, deployer.address
+            DIAMOND_ARTIFACT["Diamond"], [cut_cut, loupe_cut], deployer.address
         ),
     )
-    diamond_address = receipt["contractAddress"]
-
-    # register extra facets using diamondCut
-    await IDiamondCut.fns.diamondCut(
-        [loupe_cut, ownership_cut], ZERO_ADDRESS, b""
-    ).transact(w3, deployer, to=diamond_address)
-
-    return diamond_address, cut_address, loupe_address, ownership_address
+    return receipt["contractAddress"]
 
 
 async def test_diamond(mantra):
     w3: AsyncWeb3 = mantra.async_w3
     deployer = ACCOUNTS["community"]
+    diamond = await deploy_diamond(w3, deployer)
 
-    diamond_address, cut_address, loupe_address, ownership_address = (
-        await deploy_diamond(w3, deployer)
+    # cut diamond
+    ownership_address = await ensure_deployed_by_create2(
+        w3, deployer, get_initcode(DIAMOND_ARTIFACT["OwnershipFacet"])
+    )
+    await cut_diamond(
+        w3, deployer, diamond, Facet(ownership_address, OWNERSHIP_SELECTORS)
     )
 
     # test the facet functions via diamond
-    assert deployer.address.lower() == await IERC173.fns.owner().call(
-        w3, to=diamond_address
-    )
-    exp_facets = (
-        Facet(cut_address.lower(), tuple(DIAMOND_CUT_SELECTORS)),
-        Facet(loupe_address.lower(), tuple(DIAMOND_LOUPE_SELECTORS)),
-        Facet(ownership_address.lower(), tuple(OWNERSHIP_SELECTORS)),
-    )
-    assert exp_facets == await IDiamondLoupe.fns.facets().call(w3, to=diamond_address)
+    assert deployer.address.lower() == await IERC173.fns.owner().call(w3, to=diamond)
+
+    exp_facets = (ownership_address.lower(), tuple(OWNERSHIP_SELECTORS))
+    assert exp_facets == await IDiamondLoupe.fns.facets().call(w3, to=diamond)
 
 
-async def test_add(mantra):
+async def test_cut_diamond(mantra):
     w3: AsyncWeb3 = mantra.async_w3
     deployer = ACCOUNTS["community"]
-    diamond_address, *_ = await deploy_diamond(w3, deployer)
-    greeter_address = await deploy_greeter(w3, deployer)
-    facet_cut = FacetCut(greeter_address, FacetCutAction.ADD, GREETER_SELECTORS)
-    await IDiamondCut.fns.diamondCut([facet_cut], ZERO_ADDRESS, b"").transact(
-        w3, deployer, to=diamond_address
-    )
-    # verify facet was added
-    facet_addresses = await IDiamondLoupe.fns.facetAddresses().call(
-        w3, to=diamond_address
-    )
-    assert greeter_address.lower() in [addr.lower() for addr in facet_addresses]
-    # test greeter functionality via diamond
-    await set_and_verify_greeting(w3, deployer, diamond_address, "Hello from 💎")
+    diamond = await deploy_diamond(w3, deployer)
 
-
-async def test_replace(mantra):
-    w3: AsyncWeb3 = mantra.async_w3
-    deployer = ACCOUNTS["community"]
-    greeter_v1_address = await deploy_greeter(w3, deployer)
-    greeter_v1_cut = FacetCut(greeter_v1_address, FacetCutAction.ADD, GREETER_SELECTORS)
-    diamond_address, *_ = await deploy_diamond(
-        w3, deployer, extra_facets=[greeter_v1_cut]
+    greeter1 = await ensure_deployed_by_create2(
+        w3, deployer, get_initcode(GREETER_ARTIFACT["Greeter"])
     )
-    greeting_v1 = "Hello from v1"
-    await set_and_verify_greeting(w3, deployer, diamond_address, greeting_v1)
-
-    receipt = await send_transaction(
-        w3, deployer, data=get_initcode(GREETER_ARTIFACT["Greeter"])
+    greeter2 = await ensure_deployed_by_create2(
+        w3, deployer, get_initcode(GREETER_ARTIFACT["GreeterV2"])
     )
-    greeter_v2_address = receipt["contractAddress"]
-    greeter_v2_cut = FacetCut(
-        greeter_v2_address, FacetCutAction.REPLACE, GREETER_SELECTORS
-    )
-    await IDiamondCut.fns.diamondCut([greeter_v2_cut], ZERO_ADDRESS, b"").transact(
-        w3, deployer, to=diamond_address
-    )
-    # verify selector now points to v2
-    await verify_facet_address(
-        w3, diamond_address, IGreeter.fns.greet.selector, greeter_v2_address
-    )
-    # storage should be preserved (v1 unchanged)
-    assert await IGreeter.fns.greet().call(w3, to=diamond_address) == greeting_v1
 
+    await cut_diamond(w3, deployer, diamond, Facet(greeter1, GREETER1_SELECTORS))
 
-async def test_remove(mantra):
-    w3: AsyncWeb3 = mantra.async_w3
-    deployer = ACCOUNTS["community"]
-    greeter_address = await deploy_greeter(w3, deployer)
-    greeter_cut = FacetCut(greeter_address, FacetCutAction.ADD, GREETER_SELECTORS)
-    diamond_address, *_ = await deploy_diamond(w3, deployer, extra_facets=[greeter_cut])
+    # set greet message to diamond state
+    msg = "Hello from 💎"
+    await IGreeter1.fns.setGreeting(msg).transact(w3, deployer, to=diamond)
+    assert msg == await IGreeter1.fns.greet().call(w3, to=diamond)
 
-    greeting = "greeting"
-    await set_and_verify_greeting(w3, deployer, diamond_address, greeting)
+    assert "toRemove" == await IGreeter1.fns.toRemove().call(w3, to=diamond)
 
-    # remove setGreeting function
-    set_greeting_selector = IGreeter.fns.setGreeting.selector
-    remove_cut = FacetCut(ZERO_ADDRESS, FacetCutAction.REMOVE, [set_greeting_selector])
-    await IDiamondCut.fns.diamondCut([remove_cut], ZERO_ADDRESS, b"").transact(
-        w3, deployer, to=diamond_address
-    )
-    # verify function was removed
-    await verify_facet_address(w3, diamond_address, set_greeting_selector, ZERO_ADDRESS)
-    with pytest.raises(Exception):
-        await IGreeter.fns.setGreeting("fail").call(w3, to=diamond_address)
-    assert await IGreeter.fns.greet().call(w3, to=diamond_address) == greeting
+    # upgrade to GreeterV2
+    await cut_diamond(w3, deployer, diamond, Facet(greeter2, GREETER2_SELECTORS))
+    assert "hello from v2" == await IGreeter1.fns.greet().call(w3, to=diamond)
+
+    # method removed
+    with pytest.raises(web3.exceptions.ContractCustomError):
+        await IGreeter1.fns.toRemove().call(w3, to=diamond)
+
+    # new method
+    assert "newMethod" == await IGreeter2.fns.newMethod().call(w3, to=diamond)

--- a/integration_tests/test_diamond.py
+++ b/integration_tests/test_diamond.py
@@ -69,8 +69,9 @@ async def test_diamond(mantra):
     # test the facet functions via diamond
     assert deployer.address.lower() == await IERC173.fns.owner().call(w3, to=diamond)
 
-    exp_facets = (ownership_address.lower(), tuple(OWNERSHIP_SELECTORS))
-    assert exp_facets == await IDiamondLoupe.fns.facets().call(w3, to=diamond)
+    assert ownership_address.lower() == await IDiamondLoupe.fns.facetAddress(
+        OWNERSHIP_SELECTORS[0]
+    ).call(w3, to=diamond)
 
 
 async def test_cut_diamond(mantra):


### PR DESCRIPTION
Solution:
- make some generic diamond management utility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-chain Diamond (EIP-2535) support for faceted contract management and runtime facet updates.
  * Introduced a new contract variant exposing updated public greetings and an additional public method.
  * Added utilities to perform add/replace/remove facet operations.

* **Tests**
  * Updated integration tests and test utilities to cover diamond flows, facet deployment, replacement, removal, and related error cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->